### PR TITLE
🧰  Use Xcodebuild so that we can run tests on simulator.

### DIFF
--- a/.github/workflows/pull_request_checks.yaml
+++ b/.github/workflows/pull_request_checks.yaml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: 🧰 Select Xcode version
         run: sudo xcode-select -s '/Applications/Xcode_14.3.1.app/Contents/Developer'
-      - name: 🛠️ Build
-         run: cd nibbles && xcodebuild test -scheme "Nibbles-Package" -destination "OS=16.4,name=iPhone 14 Pro"
       - name: 🧪 Run tests
-        run: swift test --package-path nibbles
+        working-directory: nibbles
+        run: xcodebuild test -scheme "Nibbles-Package" -destination "OS=16.4,name=iPhone 14 Pro"

--- a/.github/workflows/pull_request_checks.yaml
+++ b/.github/workflows/pull_request_checks.yaml
@@ -16,6 +16,6 @@ jobs:
       - name: 🧰 Select Xcode version
         run: sudo xcode-select -s '/Applications/Xcode_14.3.1.app/Contents/Developer'
       - name: 🛠️ Build
-        run: swift build --package-path nibbles
+         run: cd nibbles && xcodebuild test -scheme "Nibbles-Package" -destination "OS=16.4,name=iPhone 14 Pro"
       - name: 🧪 Run tests
         run: swift test --package-path nibbles

--- a/nibbles/Package.swift
+++ b/nibbles/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8.1
+// swift-tools-version: 5.8.0
 
 import PackageDescription
 


### PR DESCRIPTION
Uses Xcodebuild for testing rather than swift build.