### PR TITLE
[Resolves #25] Add retry after delay support.

### DIFF
--- a/.github/workflows/pull_request_checks.yaml
+++ b/.github/workflows/pull_request_checks.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: 🧰 Select Xcode Version
         run: sudo xcode-select -s "/Applications/Xcode_14.3.1.app/Contents/Developer"
       - name: 🧪 Run tests
-        run: xcodebuild test -scheme "Nibbles-Package" -testPlan "Nibbles-Package" -destination "OS=16.4,name=iPhone 14 Pro"
+        run: xcodebuild test -scheme "swift-nibbles-Package" -testPlan "swift-nibbles-Package" -destination "OS=16.4,name=iPhone 14 Pro"
       - name: 📊 Upload Coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Cache.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Cache.xcscheme
@@ -26,20 +26,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CacheTests"
-               BuildableName = "CacheTests"
-               BlueprintName = "CacheTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Tests/CacheTests/Cache.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Extensions.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Extensions.xcscheme
@@ -26,8 +26,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Tests/ExtensionsTests/Extensions.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/HTTPNetworking.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/HTTPNetworking.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Identified"
-               BuildableName = "Identified"
-               BlueprintName = "Identified"
+               BlueprintIdentifier = "HTTPNetworking"
+               BuildableName = "HTTPNetworking"
+               BlueprintName = "HTTPNetworking"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -29,7 +29,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:Tests/IdentifiedTests/Identified.xctestplan"
+            reference = "container:Tests/HTTPNetworkingTests/HTTPNetworking.xctestplan"
             default = "YES">
          </TestPlanReference>
       </TestPlans>
@@ -54,9 +54,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "Identified"
-            BuildableName = "Identified"
-            BlueprintName = "Identified"
+            BlueprintIdentifier = "HTTPNetworking"
+            BuildableName = "HTTPNetworking"
+            BlueprintName = "HTTPNetworking"
             ReferencedContainer = "container:">
          </BuildableReference>
       </MacroExpansion>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-nibbles-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-nibbles-Package.xcscheme
@@ -127,8 +127,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:Tests/Nibbles-Package.xctestplan"
-            default = "YES">
+            reference = "container:Tests/swift-nibbles-Package.xctestplan">
          </TestPlanReference>
       </TestPlans>
       <Testables>

--- a/Sources/HTTPNetworking/HTTPRequest.swift
+++ b/Sources/HTTPNetworking/HTTPRequest.swift
@@ -80,7 +80,7 @@ public class HTTPRequest<T: Decodable> {
             // Convert data to the expected type
             return try decoder.decode(T.self, from: data)
         } catch {
-            let strategy = await ZipRetrier(retriers).retry(request, for: dispatcher.session, dueTo: error)
+            let strategy = try await ZipRetrier(retriers).retry(request, for: dispatcher.session, dueTo: error)
             switch strategy {
             case .concede:
                 throw error

--- a/Sources/HTTPNetworking/HTTPRequest.swift
+++ b/Sources/HTTPNetworking/HTTPRequest.swift
@@ -84,6 +84,9 @@ public class HTTPRequest<T: Decodable> {
             switch strategy {
             case .concede:
                 throw error
+            case .retryAfterDelay(let delay):
+                try await Task.sleep(for: delay)
+                fallthrough
             case .retry:
                 return try await run()
             }

--- a/Sources/HTTPNetworking/Plugins/Adaptors/ZipAdaptor.swift
+++ b/Sources/HTTPNetworking/Plugins/Adaptors/ZipAdaptor.swift
@@ -28,6 +28,8 @@ public struct ZipAdaptor: HTTPRequestAdaptor {
     public func adapt(_ request: URLRequest, for session: URLSession) async throws -> URLRequest {
         var request = request
         for adaptor in adaptors {
+            try Task.checkCancellation()
+            
             request = try await adaptor.adapt(request, for: session)
         }
         

--- a/Sources/HTTPNetworking/Plugins/HTTPRequestRetrier.swift
+++ b/Sources/HTTPNetworking/Plugins/HTTPRequestRetrier.swift
@@ -7,7 +7,7 @@ import Foundation
 /// By conforming to ``HTTPRequestRetrier`` you can implement both simple and complex logic for retrying an ``HTTPRequest`` when
 /// it fails. Common uses cases include retrying a given amount of times due to a specific error such as poor network connectivity.
 public protocol HTTPRequestRetrier {
-    func retry(_ request: URLRequest, for session: URLSession, dueTo error: Error) async -> RetryStrategy
+    func retry(_ request: URLRequest, for session: URLSession, dueTo error: Error) async throws -> RetryStrategy
 }
 
 // MARK: - RetryStrategy

--- a/Sources/HTTPNetworking/Plugins/HTTPRequestRetrier.swift
+++ b/Sources/HTTPNetworking/Plugins/HTTPRequestRetrier.swift
@@ -19,4 +19,6 @@ public enum RetryStrategy {
     case concede
     /// Indicates that a failing request should be reattempted.
     case retry
+    /// Indicates that a failing request should be reattempted after provided delay.
+    case retryAfterDelay(Duration)
 }

--- a/Sources/HTTPNetworking/Plugins/HTTPResponseValidator.swift
+++ b/Sources/HTTPNetworking/Plugins/HTTPResponseValidator.swift
@@ -7,5 +7,5 @@ public typealias ValidationResult = Result<Void, Error>
 /// By conforming to ``HTTPResponseValidator`` you can implement both simple and complex logic for validating
 /// the response of an ``HTTPRequest``. Common use cases include validating the status code or headers of a response.
 public protocol HTTPResponseValidator {
-    func validate(_ response: HTTPURLResponse, for request: URLRequest, with data: Data) async -> ValidationResult
+    func validate(_ response: HTTPURLResponse, for request: URLRequest, with data: Data) async throws -> ValidationResult
 }

--- a/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
+++ b/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
@@ -33,7 +33,7 @@ public struct ZipRetrier: HTTPRequestRetrier {
             switch strategy {
             case .concede:
                 continue
-            case .retry:
+            case .retry, .retryAfterDelay:
                 return strategy
             }
         }

--- a/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
+++ b/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
@@ -25,12 +25,15 @@ public struct ZipRetrier: HTTPRequestRetrier {
     
     // MARK: ResponseValidator
     
-    public func retry(_ request: URLRequest, for session: URLSession, dueTo error: Error) async -> RetryStrategy {
+    public func retry(_ request: URLRequest, for session: URLSession, dueTo error: Error) async throws -> RetryStrategy {
         for retrier in retriers {
-            let strategy = await retrier.retry(request, for: session, dueTo: error)
-            if case .concede = strategy {
+            try Task.checkCancellation()
+            
+            let strategy = try await retrier.retry(request, for: session, dueTo: error)
+            switch strategy {
+            case .concede:
                 continue
-            } else {
+            case .retry:
                 return strategy
             }
         }

--- a/Sources/HTTPNetworking/Plugins/Validators/ZipValidator.swift
+++ b/Sources/HTTPNetworking/Plugins/Validators/ZipValidator.swift
@@ -25,9 +25,11 @@ public struct ZipValidator: HTTPResponseValidator {
     
     // MARK: ResponseValidator
     
-    public func validate(_ response: HTTPURLResponse, for request: URLRequest, with data: Data) async -> ValidationResult {
+    public func validate(_ response: HTTPURLResponse, for request: URLRequest, with data: Data) async throws -> ValidationResult {
         for validator in validators {
-            if case .failure(let error) = await validator.validate(response, for: request, with: data) {
+            try Task.checkCancellation()
+            
+            if case .failure(let error) = try await validator.validate(response, for: request, with: data) {
                 return .failure(error)
             }
         }

--- a/Tests/CacheTests/Cache.xctestplan
+++ b/Tests/CacheTests/Cache.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "F058B37F-5474-46C0-A432-D042453493AB",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "CacheTests",
+        "name" : "CacheTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/ExtensionsTests/Extensions.xctestplan
+++ b/Tests/ExtensionsTests/Extensions.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "0B61CAD2-B2A9-4C4B-B7EC-E369C6B4866B",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "ExtensionsTests",
+        "name" : "ExtensionsTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/HTTPNetworkingTests/Extensions/URL+Mock.swift
+++ b/Tests/HTTPNetworkingTests/Extensions/URL+Mock.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension URL {
+    static let mock = URL(string: "https://api.com")!
+}

--- a/Tests/HTTPNetworkingTests/Extensions/URLRequest+Mock.swift
+++ b/Tests/HTTPNetworkingTests/Extensions/URLRequest+Mock.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension URLRequest {
+    static let mock = URLRequest(url: .mock)
+}

--- a/Tests/HTTPNetworkingTests/HTTPNetworking.xctestplan
+++ b/Tests/HTTPNetworkingTests/HTTPNetworking.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "CD5F56CE-6BFC-4A34-806F-A9E6CE280CC0",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "HTTPNetworkingTests",
+        "name" : "HTTPNetworkingTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
+++ b/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
@@ -13,7 +13,7 @@ class HTTPRequestTests: XCTestCase {
     
     let strings = ["Hello", "World", "!"]
     var data: Data { try! JSONEncoder().encode(strings) }
-
+    
     // MARK: Successful Request Tests
     
     func test_request_whereRequestIsSuccessful_returnsExpectedResponse() async throws {
@@ -215,7 +215,7 @@ class HTTPRequestTests: XCTestCase {
                 adaptorOneExpectation.fulfill()
                 return request
             })
-                .adapt(with: Adaptor { request, session in
+            .adapt(with: Adaptor { request, session in
                 adaptorTwoExpectation.fulfill()
                 return request
             })
@@ -262,8 +262,8 @@ class HTTPRequestTests: XCTestCase {
                 return request
             })
             .adapt(with: Adaptor { request, session in
-               adaptorFourExpectation.fulfill()
-               return request
+                adaptorFourExpectation.fulfill()
+                return request
             })
             .run()
         
@@ -667,7 +667,7 @@ class HTTPRequestTests: XCTestCase {
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
             .run()
-    
+        
         await fulfillment(of: [retryExpectation])
     }
     
@@ -706,7 +706,7 @@ class HTTPRequestTests: XCTestCase {
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
             .run()
-    
+        
         await fulfillment(of: [retrierOneExpectation, retrierTwoExpectation])
     }
     
@@ -801,7 +801,7 @@ class HTTPRequestTests: XCTestCase {
                 return .concede
             })
             .run()
-    
+        
         await fulfillment(of: [retryExpectation])
     }
     
@@ -838,7 +838,7 @@ class HTTPRequestTests: XCTestCase {
                 return .retry
             })
             .run()
-    
+        
         await fulfillment(of: [retrierOneExpectation, retrierTwoExpectation])
     }
     
@@ -882,7 +882,7 @@ class HTTPRequestTests: XCTestCase {
         } catch {
             XCTAssertEqual((error as? URLError)?.code, expectedError.code)
         }
-    
+        
         await fulfillment(of: [
             retrierOneExpectation,
             retrierTwoExpectation,

--- a/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
+++ b/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
@@ -894,7 +894,7 @@ class HTTPRequestTests: XCTestCase {
     // MARK: Helpers
     
     func createMockUrl() -> URL {
-        URL(string: "https://api.com/\(UUID().uuidString)")!
+        .mock.appending(component: UUID().uuidString)
     }
     
     func createResponse(for url: URL, with code: Int, headerFields: [String : String] = [:]) -> HTTPURLResponse {

--- a/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
+++ b/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
@@ -996,7 +996,7 @@ class HTTPRequestTests: XCTestCase {
         let client = HTTPClient(
             dispatcher: .mock(responses: [
                 url: .init(
-                    result: .success((data, createResponse(for: url, with: 200)))
+                    result: .failure(URLError(.cannotParseResponse))
                 )
             ]),
             retriers: [

--- a/Tests/HTTPNetworkingTests/Plugins/Adaptors/AdaptorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Adaptors/AdaptorTests.swift
@@ -3,9 +3,8 @@ import XCTest
 
 class AdaptorTests: XCTestCase {
     func test_adaptor_withProvidedHandler_callsHandlerOnAdaptation() async throws {
-        let url = URL(string: "https://api.com")!
         let client = HTTPClient()
-        let request = client.request(for: .get, to: url, expecting: String.self)
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectation = expectation(description: "Expected handler to be called.")
    
         let adaptor = Adaptor { request, _ in
@@ -18,9 +17,8 @@ class AdaptorTests: XCTestCase {
     }
     
     func test_request_adaptorConvenience_isAddedToRequestAdaptors() async throws {
-        let url = URL(string: "https://api.com")!
         let client = HTTPClient()
-        let request = client.request(for: .get, to: url, expecting: String.self)
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectation = expectation(description: "Expected adaptor to be called.")
         request.adapt { request, _ in
             expectation.fulfill()

--- a/Tests/HTTPNetworkingTests/Plugins/Adaptors/HeadersAdaptorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Adaptors/HeadersAdaptorTests.swift
@@ -14,7 +14,7 @@ class HeadersAdaptorTests: XCTestCase {
         ], strategy: .useOlderValue)
         
         let adaptor = ZipAdaptor([headerAdaptorOne, headerAdaptorTwo])
-        let request = try await adaptor.adapt(URLRequest(url: URL(string: "https://api.com")!), for: .shared)
+        let request = try await adaptor.adapt(URLRequest(url: .mock), for: .shared)
         
         XCTAssertEqual(request.allHTTPHeaderFields, [
             "HEADER-ONE": "VALUE-ONE-OLD",
@@ -35,7 +35,7 @@ class HeadersAdaptorTests: XCTestCase {
         ], strategy: .useNewerValue)
         
         let adaptor = ZipAdaptor([headerAdaptorOne, headerAdaptorTwo])
-        let request = try await adaptor.adapt(URLRequest(url: URL(string: "https://api.com")!), for: .shared)
+        let request = try await adaptor.adapt(URLRequest(url: .mock), for: .shared)
         
         XCTAssertEqual(request.allHTTPHeaderFields, [
             "HEADER-ONE": "VALUE-ONE-OLD",
@@ -56,7 +56,7 @@ class HeadersAdaptorTests: XCTestCase {
         ], strategy: .useBothValues)
         
         let adaptor = ZipAdaptor([headerAdaptorOne, headerAdaptorTwo])
-        let request = try await adaptor.adapt(URLRequest(url: URL(string: "https://api.com")!), for: .shared)
+        let request = try await adaptor.adapt(URLRequest(url: .mock), for: .shared)
         
         XCTAssertEqual(request.allHTTPHeaderFields, [
             "HEADER-ONE": "VALUE-ONE-OLD",
@@ -81,7 +81,7 @@ class HeadersAdaptorTests: XCTestCase {
         }))
         
         let adaptor = ZipAdaptor([headerAdaptorOne, headerAdaptorTwo])
-        let request = try await adaptor.adapt(URLRequest(url: URL(string: "https://api.com")!), for: .shared)
+        let request = try await adaptor.adapt(URLRequest(url: .mock), for: .shared)
         
         XCTAssertEqual(request.allHTTPHeaderFields, [
             "HEADER-ONE": "VALUE-ONE-OLD",
@@ -93,9 +93,8 @@ class HeadersAdaptorTests: XCTestCase {
     }
     
     func test_request_adaptorConvenience_isAddedToRequestAdaptors() async throws {
-        let url = URL(string: "https://api.com")!
         let client = HTTPClient()
-        let request = client.request(for: .get, to: url, expecting: String.self)
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
         
         let headers: [String: String] = [
             "HEADER-ONE": "VALUE-ONE",

--- a/Tests/HTTPNetworkingTests/Plugins/Adaptors/HeadersAdaptorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Adaptors/HeadersAdaptorTests.swift
@@ -14,7 +14,7 @@ class HeadersAdaptorTests: XCTestCase {
         ], strategy: .useOlderValue)
         
         let adaptor = ZipAdaptor([headerAdaptorOne, headerAdaptorTwo])
-        let request = try await adaptor.adapt(URLRequest(url: .mock), for: .shared)
+        let request = try await adaptor.adapt(.mock, for: .shared)
         
         XCTAssertEqual(request.allHTTPHeaderFields, [
             "HEADER-ONE": "VALUE-ONE-OLD",
@@ -35,7 +35,7 @@ class HeadersAdaptorTests: XCTestCase {
         ], strategy: .useNewerValue)
         
         let adaptor = ZipAdaptor([headerAdaptorOne, headerAdaptorTwo])
-        let request = try await adaptor.adapt(URLRequest(url: .mock), for: .shared)
+        let request = try await adaptor.adapt(.mock, for: .shared)
         
         XCTAssertEqual(request.allHTTPHeaderFields, [
             "HEADER-ONE": "VALUE-ONE-OLD",
@@ -56,7 +56,7 @@ class HeadersAdaptorTests: XCTestCase {
         ], strategy: .useBothValues)
         
         let adaptor = ZipAdaptor([headerAdaptorOne, headerAdaptorTwo])
-        let request = try await adaptor.adapt(URLRequest(url: .mock), for: .shared)
+        let request = try await adaptor.adapt(.mock, for: .shared)
         
         XCTAssertEqual(request.allHTTPHeaderFields, [
             "HEADER-ONE": "VALUE-ONE-OLD",
@@ -81,7 +81,7 @@ class HeadersAdaptorTests: XCTestCase {
         }))
         
         let adaptor = ZipAdaptor([headerAdaptorOne, headerAdaptorTwo])
-        let request = try await adaptor.adapt(URLRequest(url: .mock), for: .shared)
+        let request = try await adaptor.adapt(.mock, for: .shared)
         
         XCTAssertEqual(request.allHTTPHeaderFields, [
             "HEADER-ONE": "VALUE-ONE-OLD",

--- a/Tests/HTTPNetworkingTests/Plugins/Adaptors/ParametersAdaptorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Adaptors/ParametersAdaptorTests.swift
@@ -10,7 +10,7 @@ class ParametersAdaptorTests: XCTestCase {
         
         let adaptor = ParametersAdaptor(items: items)
         
-        let cleanUrlRequest = URLRequest(url: .mock)
+        let cleanUrlRequest = URLRequest.mock
         let adaptedCleanUrlRequest = try await adaptor.adapt(cleanUrlRequest, for: .shared)
         XCTAssertEqual(
             adaptedCleanUrlRequest.url,

--- a/Tests/HTTPNetworkingTests/Plugins/Adaptors/ZipAdaptorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Adaptors/ZipAdaptorTests.swift
@@ -45,7 +45,7 @@ class ZipAdaptorTests: XCTestCase {
         
         task = Task {
             do {
-                _ = try await zipAdaptor.adapt(URLRequest(url: .mock), for: .shared)
+                _ = try await zipAdaptor.adapt(.mock, for: .shared)
             } catch {
                 XCTAssertTrue(error is CancellationError)
             }

--- a/Tests/HTTPNetworkingTests/Plugins/Adaptors/ZipAdaptorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Adaptors/ZipAdaptorTests.swift
@@ -44,9 +44,8 @@ class ZipAdaptorTests: XCTestCase {
         ])
         
         task = Task {
-            let url = URL(string: "https://api.com")!
             do {
-                _ = try await zipAdaptor.adapt(URLRequest(url: url), for: .shared)
+                _ = try await zipAdaptor.adapt(URLRequest(url: .mock), for: .shared)
             } catch {
                 XCTAssertTrue(error is CancellationError)
             }

--- a/Tests/HTTPNetworkingTests/Plugins/Retriers/RetrierTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Retriers/RetrierTests.swift
@@ -4,9 +4,8 @@ import XCTest
 class RetrierTests: XCTestCase {
     func test_retrier_withProvidedHandler_callsHandlerOnRetry() async throws {
         
-        let url = URL(string: "https://api.com")!
         let client = HTTPClient()
-        let request = client.request(for: .get, to: url, expecting: String.self)
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectation = expectation(description: "Expected handler to be called.")
    
         let retrier = Retrier { _, _, _ in
@@ -21,9 +20,8 @@ class RetrierTests: XCTestCase {
     func test_request_retryConvenience_isAddedToRequestRetriers() async throws {
         struct MockError: Error {}
         
-        let url = URL(string: "https://api.com")!
         let client = HTTPClient()
-        let request = client.request(for: .get, to: url, expecting: String.self)
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectation = expectation(description: "Expected retrier to be called.")
         request.retry { _, _, _ in
             expectation.fulfill()

--- a/Tests/HTTPNetworkingTests/Plugins/Retriers/RetrierTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Retriers/RetrierTests.swift
@@ -18,7 +18,7 @@ class RetrierTests: XCTestCase {
         await fulfillment(of: [expectation])
     }
     
-    func test_request_retryConvenience_isAddedToRequestRetriers() async {
+    func test_request_retryConvenience_isAddedToRequestRetriers() async throws {
         struct MockError: Error {}
         
         let url = URL(string: "https://api.com")!
@@ -30,7 +30,7 @@ class RetrierTests: XCTestCase {
             return .concede
         }
         
-        _ = await request.retriers.first?.retry(
+        _ = try await request.retriers.first?.retry(
             request.request,
             for: client.dispatcher.session,
             dueTo: MockError()

--- a/Tests/HTTPNetworkingTests/Plugins/Retriers/ZipRetrierTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Retriers/ZipRetrierTests.swift
@@ -45,7 +45,7 @@ class ZipRetrierTests: XCTestCase {
         
         task = Task {
             do {
-                _ = try await zipRetrier.retry(URLRequest(url: .mock), for: .shared, dueTo: URLError(.cannotParseResponse))
+                _ = try await zipRetrier.retry(.mock, for: .shared, dueTo: URLError(.cannotParseResponse))
             } catch {
                 XCTAssertTrue(error is CancellationError)
             }

--- a/Tests/HTTPNetworkingTests/Plugins/Retriers/ZipRetrierTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Retriers/ZipRetrierTests.swift
@@ -44,9 +44,8 @@ class ZipRetrierTests: XCTestCase {
         ])
         
         task = Task {
-            let url = URL(string: "https://api.com")!
             do {
-                _ = try await zipRetrier.retry(URLRequest(url: url), for: .shared, dueTo: URLError(.cannotParseResponse))
+                _ = try await zipRetrier.retry(URLRequest(url: .mock), for: .shared, dueTo: URLError(.cannotParseResponse))
             } catch {
                 XCTAssertTrue(error is CancellationError)
             }

--- a/Tests/HTTPNetworkingTests/Plugins/Validators/StatusCodeValidatorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Validators/StatusCodeValidatorTests.swift
@@ -3,35 +3,33 @@ import XCTest
 
 class StatusCodeValidatorTests: XCTestCase {
     func test_statusCodeValidator_withSequenceOfStatusCodes_succeedsWhenCodeIsInRange() async {
-        let url = URL(string: "https://api.com")!
-        let request = URLRequest(url: url)
+        let request = URLRequest(url: .mock)
         let validator = StatusCodeValidator(statusCode: 200...299)
         
-        let lowerBoundResponse = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        let lowerBoundResponse = HTTPURLResponse(url: .mock, statusCode: 200, httpVersion: nil, headerFields: nil)!
         let lowerBoundResult = await validator.validate(lowerBoundResponse, for: request, with: Data())
         XCTAssertNoThrow(try lowerBoundResult.get())
         
-        let withinBoundResponse = HTTPURLResponse(url: url, statusCode: 250, httpVersion: nil, headerFields: nil)!
+        let withinBoundResponse = HTTPURLResponse(url: .mock, statusCode: 250, httpVersion: nil, headerFields: nil)!
         let withinBoundResult = await validator.validate(withinBoundResponse, for: request, with: Data())
         XCTAssertNoThrow(try withinBoundResult.get())
         
-        let upperBoundResponse = HTTPURLResponse(url: url, statusCode: 299, httpVersion: nil, headerFields: nil)!
+        let upperBoundResponse = HTTPURLResponse(url: .mock, statusCode: 299, httpVersion: nil, headerFields: nil)!
         let upperBoundResult = await validator.validate(upperBoundResponse, for: request, with: Data())
         XCTAssertNoThrow(try upperBoundResult.get())
     }
     
     func test_statusCodeValidator_withSequenceOfStatusCodes_failsWhenCodeIsOutOfRange() async {
-        let url = URL(string: "https://api.com")!
-        let request = URLRequest(url: url)
+        let request = URLRequest(url: .mock)
         let validator = StatusCodeValidator(statusCode: 200...299)
         
-        let lowerThanBoundResponse = HTTPURLResponse(url: url, statusCode: 199, httpVersion: nil, headerFields: nil)!
+        let lowerThanBoundResponse = HTTPURLResponse(url: .mock, statusCode: 199, httpVersion: nil, headerFields: nil)!
         let lowerThanBoundResult = await validator.validate(lowerThanBoundResponse, for: request, with: Data())
         XCTAssertThrowsError(try lowerThanBoundResult.get()) { error in
             XCTAssertEqual((error as? StatusCodeValidatorError)?.code, 199)
         }
         
-        let higherThanBoundResponse = HTTPURLResponse(url: url, statusCode: 300, httpVersion: nil, headerFields: nil)!
+        let higherThanBoundResponse = HTTPURLResponse(url: .mock, statusCode: 300, httpVersion: nil, headerFields: nil)!
         let heigherThanBoundResult = await validator.validate(higherThanBoundResponse, for: request, with: Data())
         XCTAssertThrowsError(try heigherThanBoundResult.get()) { error in
             XCTAssertEqual((error as? StatusCodeValidatorError)?.code, 300)
@@ -39,27 +37,25 @@ class StatusCodeValidatorTests: XCTestCase {
     }
     
     func test_statusCodeValidator_withSingleStatusCode_succeedsWhenCodeIsInRange() async {
-        let url = URL(string: "https://api.com")!
-        let request = URLRequest(url: url)
+        let request = URLRequest(url: .mock)
         let validator = StatusCodeValidator(statusCode: 200)
         
-        let successfulResponse = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        let successfulResponse = HTTPURLResponse(url: .mock, statusCode: 200, httpVersion: nil, headerFields: nil)!
         let successfulResult = await validator.validate(successfulResponse, for: request, with: Data())
         XCTAssertNoThrow(try successfulResult.get())
     }
     
     func test_statusCodeValidator_withSingleStatusCode_failsWhenCodeIsOutOfRange() async {
-        let url = URL(string: "https://api.com")!
-        let request = URLRequest(url: url)
+        let request = URLRequest(url: .mock)
         let validator = StatusCodeValidator(statusCode: 200)
         
-        let lowerThanBoundResponse = HTTPURLResponse(url: url, statusCode: 199, httpVersion: nil, headerFields: nil)!
+        let lowerThanBoundResponse = HTTPURLResponse(url: .mock, statusCode: 199, httpVersion: nil, headerFields: nil)!
         let lowerThanBoundResult = await validator.validate(lowerThanBoundResponse, for: request, with: Data())
         XCTAssertThrowsError(try lowerThanBoundResult.get()) { error in
             XCTAssertEqual((error as? StatusCodeValidatorError)?.code, 199)
         }
         
-        let higherThanBoundResponse = HTTPURLResponse(url: url, statusCode: 201, httpVersion: nil, headerFields: nil)!
+        let higherThanBoundResponse = HTTPURLResponse(url: .mock, statusCode: 201, httpVersion: nil, headerFields: nil)!
         let heigherThanBoundResult = await validator.validate(higherThanBoundResponse, for: request, with: Data())
         XCTAssertThrowsError(try heigherThanBoundResult.get()) { error in
             XCTAssertEqual((error as? StatusCodeValidatorError)?.code, 201)
@@ -67,9 +63,8 @@ class StatusCodeValidatorTests: XCTestCase {
     }
     
     func test_request_singleStatusCodeValidationConvenience_isAddedToRequestValidators() async {
-        let url = URL(string: "https://api.com")!
         let client = HTTPClient()
-        let request = client.request(for: .get, to: url, expecting: String.self)
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
         request.validate(statusCode: 200)
         guard let validator = request.validators.first as? StatusCodeValidator<ClosedRange<Int>> else {
             XCTFail("Expected a ClosedRange<Int> StatusCodeValidator")
@@ -80,9 +75,8 @@ class StatusCodeValidatorTests: XCTestCase {
     }
     
     func test_request_sequenceStatusCodeValidationConvenience_isAddedToRequestValidators() async {
-        let url = URL(string: "https://api.com")!
         let client = HTTPClient()
-        let request = client.request(for: .get, to: url, expecting: String.self)
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
         request.validate(statusCode: 200...299)
         guard let validator = request.validators.first as? StatusCodeValidator<ClosedRange<Int>> else {
             XCTFail("Expected a ClosedRange<Int> StatusCodeValidator")

--- a/Tests/HTTPNetworkingTests/Plugins/Validators/StatusCodeValidatorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Validators/StatusCodeValidatorTests.swift
@@ -3,60 +3,56 @@ import XCTest
 
 class StatusCodeValidatorTests: XCTestCase {
     func test_statusCodeValidator_withSequenceOfStatusCodes_succeedsWhenCodeIsInRange() async {
-        let request = URLRequest(url: .mock)
         let validator = StatusCodeValidator(statusCode: 200...299)
         
         let lowerBoundResponse = HTTPURLResponse(url: .mock, statusCode: 200, httpVersion: nil, headerFields: nil)!
-        let lowerBoundResult = await validator.validate(lowerBoundResponse, for: request, with: Data())
+        let lowerBoundResult = await validator.validate(lowerBoundResponse, for: .mock, with: Data())
         XCTAssertNoThrow(try lowerBoundResult.get())
         
         let withinBoundResponse = HTTPURLResponse(url: .mock, statusCode: 250, httpVersion: nil, headerFields: nil)!
-        let withinBoundResult = await validator.validate(withinBoundResponse, for: request, with: Data())
+        let withinBoundResult = await validator.validate(withinBoundResponse, for: .mock, with: Data())
         XCTAssertNoThrow(try withinBoundResult.get())
         
         let upperBoundResponse = HTTPURLResponse(url: .mock, statusCode: 299, httpVersion: nil, headerFields: nil)!
-        let upperBoundResult = await validator.validate(upperBoundResponse, for: request, with: Data())
+        let upperBoundResult = await validator.validate(upperBoundResponse, for: .mock, with: Data())
         XCTAssertNoThrow(try upperBoundResult.get())
     }
     
     func test_statusCodeValidator_withSequenceOfStatusCodes_failsWhenCodeIsOutOfRange() async {
-        let request = URLRequest(url: .mock)
         let validator = StatusCodeValidator(statusCode: 200...299)
         
         let lowerThanBoundResponse = HTTPURLResponse(url: .mock, statusCode: 199, httpVersion: nil, headerFields: nil)!
-        let lowerThanBoundResult = await validator.validate(lowerThanBoundResponse, for: request, with: Data())
+        let lowerThanBoundResult = await validator.validate(lowerThanBoundResponse, for: .mock, with: Data())
         XCTAssertThrowsError(try lowerThanBoundResult.get()) { error in
             XCTAssertEqual((error as? StatusCodeValidatorError)?.code, 199)
         }
         
         let higherThanBoundResponse = HTTPURLResponse(url: .mock, statusCode: 300, httpVersion: nil, headerFields: nil)!
-        let heigherThanBoundResult = await validator.validate(higherThanBoundResponse, for: request, with: Data())
+        let heigherThanBoundResult = await validator.validate(higherThanBoundResponse, for: .mock, with: Data())
         XCTAssertThrowsError(try heigherThanBoundResult.get()) { error in
             XCTAssertEqual((error as? StatusCodeValidatorError)?.code, 300)
         }
     }
     
     func test_statusCodeValidator_withSingleStatusCode_succeedsWhenCodeIsInRange() async {
-        let request = URLRequest(url: .mock)
         let validator = StatusCodeValidator(statusCode: 200)
         
         let successfulResponse = HTTPURLResponse(url: .mock, statusCode: 200, httpVersion: nil, headerFields: nil)!
-        let successfulResult = await validator.validate(successfulResponse, for: request, with: Data())
+        let successfulResult = await validator.validate(successfulResponse, for: .mock, with: Data())
         XCTAssertNoThrow(try successfulResult.get())
     }
     
     func test_statusCodeValidator_withSingleStatusCode_failsWhenCodeIsOutOfRange() async {
-        let request = URLRequest(url: .mock)
         let validator = StatusCodeValidator(statusCode: 200)
         
         let lowerThanBoundResponse = HTTPURLResponse(url: .mock, statusCode: 199, httpVersion: nil, headerFields: nil)!
-        let lowerThanBoundResult = await validator.validate(lowerThanBoundResponse, for: request, with: Data())
+        let lowerThanBoundResult = await validator.validate(lowerThanBoundResponse, for: .mock, with: Data())
         XCTAssertThrowsError(try lowerThanBoundResult.get()) { error in
             XCTAssertEqual((error as? StatusCodeValidatorError)?.code, 199)
         }
         
         let higherThanBoundResponse = HTTPURLResponse(url: .mock, statusCode: 201, httpVersion: nil, headerFields: nil)!
-        let heigherThanBoundResult = await validator.validate(higherThanBoundResponse, for: request, with: Data())
+        let heigherThanBoundResult = await validator.validate(higherThanBoundResponse, for: .mock, with: Data())
         XCTAssertThrowsError(try heigherThanBoundResult.get()) { error in
             XCTAssertEqual((error as? StatusCodeValidatorError)?.code, 201)
         }

--- a/Tests/HTTPNetworkingTests/Plugins/Validators/ValidatorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Validators/ValidatorTests.swift
@@ -3,10 +3,8 @@ import XCTest
 
 class ValidatorTests: XCTestCase {
     func test_validator_withProvidedHandler_callsHandlerOnValidation() async throws {
-        
-        let url = URL(string: "https://api.com")!
         let client = HTTPClient()
-        let request = client.request(for: .get, to: url, expecting: String.self)
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectation = expectation(description: "Expected handler to be called.")
    
         let validator = Validator { _, _, _ in
@@ -19,9 +17,8 @@ class ValidatorTests: XCTestCase {
     }
     
     func test_request_validatorConvenience_isAddedToRequestValidators() async throws {
-        let url = URL(string: "https://api.com")!
         let client = HTTPClient()
-        let request = client.request(for: .get, to: url, expecting: String.self)
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectation = expectation(description: "Expected adaptor to be called.")
         request.validate { _, _, _ in
             expectation.fulfill()

--- a/Tests/HTTPNetworkingTests/Plugins/Validators/ValidatorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Validators/ValidatorTests.swift
@@ -28,7 +28,7 @@ class ValidatorTests: XCTestCase {
             return .success
         }
         
-        _ = await request.validators.first?.validate(HTTPURLResponse(), for: request.request, with: Data())
+        _ = try await request.validators.first?.validate(HTTPURLResponse(), for: request.request, with: Data())
         
         await fulfillment(of: [expectation])
     }

--- a/Tests/HTTPNetworkingTests/Plugins/Validators/ZipValidatorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Validators/ZipValidatorTests.swift
@@ -44,9 +44,8 @@ class ZipValidatorTests: XCTestCase {
         ])
         
         task = Task {
-            let url = URL(string: "https://api.com")!
             do {
-                _ = try await zipValidator.validate(HTTPURLResponse(), for: URLRequest(url: url), with: Data())
+                _ = try await zipValidator.validate(HTTPURLResponse(), for: URLRequest(url: .mock), with: Data())
             } catch {
                 XCTAssertTrue(error is CancellationError)
             }

--- a/Tests/HTTPNetworkingTests/Plugins/Validators/ZipValidatorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Validators/ZipValidatorTests.swift
@@ -21,4 +21,37 @@ class ZipValidatorTests: XCTestCase {
         let variadicZip = ZipValidator(one, two, three)
         XCTAssertEqual(variadicZip.validators as? [TestValidator], expectedValidators)
     }
+    
+    func test_zipValidator_whenCancelled_stopsIteratingThroughValidators() async {
+        var task: Task<Void, Error>?
+        let validatorOneExpectation = expectation(description: "Expected validator one to be executed.")
+        let validatorTwoExpectation = expectation(description: "Expected validator two to be executed.")
+        
+        let zipValidator = ZipValidator([
+            Validator { _, _, _ in
+                validatorOneExpectation.fulfill()
+                return .success
+            },
+            Validator { _, _, _ in
+                validatorTwoExpectation.fulfill()
+                task?.cancel()
+                return .success
+            },
+            Validator { _, _, _ in
+                XCTFail("Expected task to be cancelled and third validator to be skipped.")
+                return .success
+            }
+        ])
+        
+        task = Task {
+            let url = URL(string: "https://api.com")!
+            do {
+                _ = try await zipValidator.validate(HTTPURLResponse(), for: URLRequest(url: url), with: Data())
+            } catch {
+                XCTAssertTrue(error is CancellationError)
+            }
+        }
+        
+        await fulfillment(of: [validatorOneExpectation, validatorTwoExpectation])
+    }
 }

--- a/Tests/HTTPNetworkingTests/Plugins/Validators/ZipValidatorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Validators/ZipValidatorTests.swift
@@ -45,7 +45,7 @@ class ZipValidatorTests: XCTestCase {
         
         task = Task {
             do {
-                _ = try await zipValidator.validate(HTTPURLResponse(), for: URLRequest(url: .mock), with: Data())
+                _ = try await zipValidator.validate(HTTPURLResponse(), for: .mock, with: Data())
             } catch {
                 XCTAssertTrue(error is CancellationError)
             }

--- a/Tests/IdentifiedTests/Identified.xctestplan
+++ b/Tests/IdentifiedTests/Identified.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "5A0D202E-E065-4B14-9C85-0E07B52D6F42",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "IdentifiedTests",
+        "name" : "IdentifiedTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/swift-nibbles-Package.xctestplan
+++ b/Tests/swift-nibbles-Package.xctestplan
@@ -56,16 +56,16 @@
       "parallelizable" : true,
       "target" : {
         "containerPath" : "container:",
-        "identifier" : "IdentifiedTests",
-        "name" : "IdentifiedTests"
+        "identifier" : "HTTPNetworkingTests",
+        "name" : "HTTPNetworkingTests"
       }
     },
     {
       "parallelizable" : true,
       "target" : {
         "containerPath" : "container:",
-        "identifier" : "HTTPNetworkingTests",
-        "name" : "HTTPNetworkingTests"
+        "identifier" : "IdentifiedTests",
+        "name" : "IdentifiedTests"
       }
     }
   ],

--- a/Tests/swift-nibbles-Package.xctestplan
+++ b/Tests/swift-nibbles-Package.xctestplan
@@ -33,7 +33,9 @@
         }
       ]
     },
-    "testExecutionOrdering" : "random"
+    "defaultTestExecutionTimeAllowance" : 60,
+    "testExecutionOrdering" : "random",
+    "testTimeoutsEnabled" : true
   },
   "testTargets" : [
     {


### PR DESCRIPTION
Resolves #25 

- Updates plugins to all support throwing.
- Updates `ZipValidator`, ZipAdaptor` and `ZipRretrier` to check for `Task` cancellation before each child is executed.
- Adds tests to validate the task cancellation.
- Cleanup tests by using mock url/request static properties rather than strings/repeated work.
- Adds tests to verify task cancellation works as expected on requests.
- Updates schemes with test plans for each target, allowing tests to be run individually
- Adds a default timeout for the greater test plan.
- Adds support for retry after delay.