### PR TITLE
♻️  Reorders plugins to better represent stages.

### DIFF
--- a/Sources/HTTPNetworking/HTTPClient.swift
+++ b/Sources/HTTPNetworking/HTTPClient.swift
@@ -71,11 +71,11 @@ public struct HTTPClient {
     /// A collection of adaptors that adapt each request.
     public let adaptors: [any HTTPRequestAdaptor]
     
-    /// A collection of retriers that handle retrying failed requests.
-    public let retriers: [any HTTPRequestRetrier]
-    
     /// A collection of validators that validate each response.
     public let validators: [any HTTPResponseValidator]
+    
+    /// A collection of retriers that handle retrying failed requests.
+    public let retriers: [any HTTPRequestRetrier]
     
     // MARK: Initializers
     
@@ -86,15 +86,15 @@ public struct HTTPClient {
     ///   - decoder: The decoder that each request should use to decode response bodies.
     ///   - dispatcher: The dispatcher that will actually send out each request.
     ///   - adaptors: A collection of adaptors that adapt each request.
-    ///   - retriers: A collection of retriers that handle retrying failed requests.
     ///   - validators: A collection of validators that validate each response.
+    ///   - retriers: A collection of retriers that handle retrying failed requests.
     public init(
         encoder: JSONEncoder = JSONEncoder(),
         decoder: JSONDecoder = JSONDecoder(),
         dispatcher: HTTPDispatcher = .live(),
         adaptors: [any HTTPRequestAdaptor] = [],
-        retriers: [any HTTPRequestRetrier] = [],
-        validators: [any HTTPResponseValidator] = []
+        validators: [any HTTPResponseValidator] = [],
+        retriers: [any HTTPRequestRetrier] = []
     ) {
         self.encoder = encoder
         self.decoder = decoder

--- a/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
+++ b/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
@@ -917,16 +917,16 @@ class HTTPRequestTests: XCTestCase {
                     return request
                 },
             ],
-            retriers: [
-                Retrier { _, _, _ in
-                    XCTFail("Retrier should not have been called after task cancellation.")
-                    return .concede
-                }
-            ],
             validators: [
                 Validator { _, _, _ in
                     XCTFail("Validator should not have been called after task cancellation.")
                     return .success
+                }
+            ],
+            retriers: [
+                Retrier { _, _, _ in
+                    XCTFail("Retrier should not have been called after task cancellation.")
+                    return .concede
                 }
             ]
         )
@@ -956,12 +956,6 @@ class HTTPRequestTests: XCTestCase {
                     result: .success((data, createResponse(for: url, with: 200)))
                 )
             ]),
-            retriers: [
-                Retrier { _, _, _ in
-                    XCTFail("Retrier should not have been called after task cancellation.")
-                    return .concede
-                }
-            ],
             validators: [
                 Validator { _, _, _ in
                     task?.cancel()
@@ -970,6 +964,12 @@ class HTTPRequestTests: XCTestCase {
                 Validator { _, _, _ in
                     XCTFail("Second validator should not have been called after task cancellation.")
                     return .success
+                }
+            ],
+            retriers: [
+                Retrier { _, _, _ in
+                    XCTFail("Retrier should not have been called after task cancellation.")
+                    return .concede
                 }
             ]
         )


### PR DESCRIPTION
It is more appropriate for validators to come before retriers when constructing a client. This decision is primarily made due to the fact that validators are executed before retriers logically.