### PR TITLE
[Resolves #10] ✨Add Sample Retrier

### DIFF
--- a/Sources/Extensions/Array.swift
+++ b/Sources/Extensions/Array.swift
@@ -4,8 +4,7 @@ extension Array {
     /// Splits the array into chunks of the specified size.
     public func chunked(into size: Int) -> [[Element]] {
         guard size > 0 else {
-            assertionFailure("Size must not be zero.")
-            return []
+            preconditionFailure("Size must be greater than zero.")
         }
         
         return stride(from: 0, to: count, by: size).map {

--- a/Sources/HTTPNetworking/HTTPClient.swift
+++ b/Sources/HTTPNetworking/HTTPClient.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// `HTTPClient` creates and manages requests over the network.
 ///
-/// The client also provides common functionality for all  ``HTTPRequest`` objects, including encoding and decoding strategies,
+/// The client provides common functionality for all  ``HTTPRequest`` objects, including encoding and decoding strategies,
 /// request adaptation, response validation and retry stratagies.
 ///
 /// Generally an ``HTTPClient`` is used to manage the interaction with a single API service. Most APIs
@@ -12,19 +12,36 @@ import Foundation
 /// If your API requires a custom encoder or decoder, you can provide your own custom ones to the client. These encoder and decoders
 /// will then be used for all requests made using the client.
 ///
+/// ## Adaptors
+///
 /// If your API requires some sort of repetitive task applied to each request, rather than manipulating it at each call, you can make use of an
 /// ``HTTPRequestAdaptor``. The adaptors that you provide to the client will all be run on a request before it is sent to your API.
 /// This provides you with an opportunity to insert various headers or perform asyncrounous tasks before sending the outbound request.
+///
+/// > Important: All adaptors will always run for every request.
+///
+/// ## Validators
 ///
 /// Different APIs require different forms of validation that help you determine if a request was successful or not.
 /// The default ``HTTPClient`` makes no assumptions about the format and/or success of an API's response. Instead, you can make use of an
 /// ``HTTPResponseValidator``. The validators that you provide the client will all be run on the response received by your API.
 /// This provides you with an opportunity to determine wether or not the response was a success and failure, and consolidate potentially repeated logic in one place.
 ///
+/// > Important: Validators will be run one by one on a request's response. If any validators determines that the response is invalid,
+/// the request will fail and throw the error returned by that validator. No other subsequent validators will be run for that run of a request.
+///
+/// ## Retriers
+///
 /// Sometimes you may want to implement logic for handling retries of failed requests. An ``HTTPClient`` can make use of an
 /// ``HTTPRequestRetriers``. The retriers that you provide the client will be run when a request fails.
 /// This provides you with an opportunity to observe the error and determine wether or not the request should be sent again. You can implement complex retry
 /// logic across your entire client without having to repeat yourself.
+///
+/// > Important: Retriers will be run one by one in the event of a failed request. If any retrier concedes that the request should not be retried,
+/// the request will ask the next retrier if the request should be retried. If any retrier determines that a request should be retired, the request will
+/// immedietly be retired, without asking any subsequent retriers.
+///
+/// ## Request Manipulation
 ///
 /// In addition to providing adaptors, validators and retriers to your entire client, you can provide additional configuration to each
 /// request using a chaining style syntax. This allows you to add additional configuration to endpoints that you may want to provide further
@@ -44,17 +61,7 @@ import Foundation
 /// let response = try await request.run()
 /// ```
 ///
-/// > Note: All adaptors, validators and retriers at the client level will be run first, after which the
-/// request configurations at the request level will be run.
-///
-/// > Important: All adaptors will always run for every request.
-///
-/// > Important: Validators will be run one by one on a request's response. If any validators determines that the response is invalid,
-/// the request will fail and throw the error returned by that validator. No other subsequent validators will be run for that run of a request.
-///
-/// > Important: Retriers will be run one by one in the event of a failred request. If any retrier concedes that the request should not be retried,
-/// the request will ask the next retrier if the request should be retried. If any retrier determines that a request should be retired, the request will
-/// immedietly be retired, without asking any subsequent retriers.
+/// > Note: For all adaptors, validators and retriers, the client level plugins will run before the request level plugins
 public struct HTTPClient {
     
     // MARK: Properties

--- a/Sources/HTTPNetworking/HTTPDispatcher.swift
+++ b/Sources/HTTPNetworking/HTTPDispatcher.swift
@@ -18,7 +18,7 @@ public struct HTTPDispatcher {
     }
     
     /// Fetches data using the provided request.
-    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+    func data(for request: URLRequest) async throws -> (data: Data, response: HTTPURLResponse) {
         let (data, response) = try await session.data(for: request)
         guard let response = response as? HTTPURLResponse else {
             throw URLError(.cannotParseResponse)
@@ -46,7 +46,7 @@ extension HTTPDispatcher {
     /// A mock implementation of an ``HTTPDispatcher`` that will return the provided
     /// response to the corresponding request.
     ///
-    /// - Parameter responses: A dictionary of responses keyed by the requests for which they should respond to.
+    /// - Parameter responses: A dictionary of responses keyed by the urls for which they should respond to.
     /// - Returns: An ``HTTPDispatcher``
     public static func mock(
         responses: [URL: MockResponse]

--- a/Sources/HTTPNetworking/HTTPMethod.swift
+++ b/Sources/HTTPNetworking/HTTPMethod.swift
@@ -1,23 +1,39 @@
 import Foundation
 
-/// An HTTP method for an HTTP request.
-public enum HTTPMethod: String {
-    /// The GET method requests a representation of the specified resource. Requests using GET should only retrieve data.
-    case get
-    /// The HEAD method asks for a response identical to that of a GET request, but without the response body.
-    case head
-    /// The POST method is used to submit an entity to the specified resource, often causing a change in state or side effects on the server.
-    case post
-    /// The PUT method replaces all current representations of the target resource with the request payload.
-    case put
-    /// The DELETE method deletes the specified resource.
-    case delete
-    /// The CONNECT method establishes a tunnel to the server identified by the target resource.
-    case connect
-    /// The OPTIONS method is used to describe the communication options for the target resource.
-    case options
-    /// The TRACE method performs a message loop-back test along the path to the target resource.
-    case trace
-    /// The PATCH method is used to apply partial modifications to a resource.
-    case patch
+/// A type representing HTTP methods.
+///
+/// See [RFC 9110 - Section 9](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods) for more information.
+public struct HTTPMethod: RawRepresentable, Equatable, Hashable {
+    /// The `GET` method requests a representation of the specified resource. Requests using GET should only retrieve data.
+    public static let get = HTTPMethod(rawValue: "GET")
+    
+    /// The `HEAD` method asks for a response identical to that of a GET request, but without the response body.
+    public static let head = HTTPMethod(rawValue: "HEAD")
+    
+    /// The `POST` method is used to submit an entity to the specified resource, often causing a change in state or side effects on the server.
+    public static let post = HTTPMethod(rawValue: "POST")
+    
+    /// The `PUT` method replaces all current representations of the target resource with the request payload.
+    public static let put = HTTPMethod(rawValue: "PUT")
+    
+    /// The `DELETE` method deletes the specified resource.
+    public static let delete = HTTPMethod(rawValue: "DELETE")
+    
+    /// The `CONNECT` method establishes a tunnel to the server identified by the target resource.
+    public static let connect = HTTPMethod(rawValue: "CONNECT")
+    
+    /// The `OPTIONS` method is used to describe the communication options for the target resource.
+    public static let options = HTTPMethod(rawValue: "OPTIONS")
+    
+    /// The `TRACE` method performs a message loop-back test along the path to the target resource.
+    public static let trace = HTTPMethod(rawValue: "TRACE")
+    
+    /// The `PATCH` method is used to apply partial modifications to a resource.
+    public static let patch = HTTPMethod(rawValue: "PATCH")
+    
+    public let rawValue: String
+    
+    public init(rawValue: String) {
+        self.rawValue = rawValue.uppercased()
+    }
 }

--- a/Sources/HTTPNetworking/Plugins/Adaptors/Adaptor.swift
+++ b/Sources/HTTPNetworking/Plugins/Adaptors/Adaptor.swift
@@ -7,7 +7,7 @@ public struct Adaptor: HTTPRequestAdaptor {
     
     // MARK: Properties
     
-    let handler: AdaptationHandler
+    private let handler: AdaptationHandler
     
     // MARK: Initializers
     

--- a/Sources/HTTPNetworking/Plugins/Adaptors/Adaptor.swift
+++ b/Sources/HTTPNetworking/Plugins/Adaptors/Adaptor.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-public typealias AdaptationHandler = (URLRequest, URLSession) async throws -> URLRequest
+public typealias AdaptationHandler = (
+    _ request: URLRequest,
+    _ session: URLSession
+) async throws -> URLRequest
 
 /// An ``HTTPRequestAdaptor`` that can be used to manipulate a `URLRequest` before it is sent out over the network.
 public struct Adaptor: HTTPRequestAdaptor {

--- a/Sources/HTTPNetworking/Plugins/Adaptors/Adaptor.swift
+++ b/Sources/HTTPNetworking/Plugins/Adaptors/Adaptor.swift
@@ -1,9 +1,13 @@
 import Foundation
 
+// MARK: - AdaptationHandler
+
 public typealias AdaptationHandler = (
     _ request: URLRequest,
     _ session: URLSession
 ) async throws -> URLRequest
+
+// MARK: - Adaptor
 
 /// An ``HTTPRequestAdaptor`` that can be used to manipulate a `URLRequest` before it is sent out over the network.
 public struct Adaptor: HTTPRequestAdaptor {

--- a/Sources/HTTPNetworking/Plugins/Adaptors/HeadersAdaptor.swift
+++ b/Sources/HTTPNetworking/Plugins/Adaptors/HeadersAdaptor.swift
@@ -23,15 +23,18 @@ public struct HeadersAdaptor: HTTPRequestAdaptor {
     
     // MARK: Properties
     
-    let headers: [String: String]
-    let strategy: CollisionStrategy
+    /// The HTTP headers to be appended to an incoming request.
+    public let headers: [String: String]
+    
+    /// The strategy to use when the adaptor encounters a field collision.
+    public let strategy: CollisionStrategy
 
     // MARK: Initializers
     
     /// Creates a ``HeadersAdaptor`` from the provided HTTP headers.
     /// 
     /// - Parameters:
-    ///   - headers: The HTTP headers to append to incoming requests.
+    ///   - headers: The HTTP headers to be appended to an incoming request.
     ///   - strategy: The strategy to use when the adaptor encounters a field collision.
     public init(headers: [String: String], strategy: CollisionStrategy) {
         self.headers = headers

--- a/Sources/HTTPNetworking/Plugins/Adaptors/HeadersAdaptor.swift
+++ b/Sources/HTTPNetworking/Plugins/Adaptors/HeadersAdaptor.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - HeadersAdaptor
+
 /// An ``HTTPRequestAdaptor`` that can be used to append HTTP headers to a request before it is sent out over the network.
 public struct HeadersAdaptor: HTTPRequestAdaptor {
 

--- a/Sources/HTTPNetworking/Plugins/Adaptors/ParametersAdaptor.swift
+++ b/Sources/HTTPNetworking/Plugins/Adaptors/ParametersAdaptor.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - ParametersAdaptor
+
 /// An ``HTTPRequestAdaptor`` that can be used to append query parameters to a request before it is sent out over the network.
 ///
 /// > Warning: This adaptor will **not** overwrite existing parameters, instead it will append to existing parameters.

--- a/Sources/HTTPNetworking/Plugins/Adaptors/ParametersAdaptor.swift
+++ b/Sources/HTTPNetworking/Plugins/Adaptors/ParametersAdaptor.swift
@@ -7,13 +7,14 @@ public struct ParametersAdaptor: HTTPRequestAdaptor {
     
     // MARK: Properties
     
-    let items: [URLQueryItem]
+    /// The query parameters to append to an incoming request.
+    public let items: [URLQueryItem]
     
     // MARK: Initializers
     
     /// Creates a ``ParametersAdaptor`` from the provided query parameters.
     ///
-    /// - Parameter items: The query parameters to append to incoming requests.
+    /// - Parameter items: The query parameters to append to an incoming request.
     public init(items: [URLQueryItem]) {
         self.items = items
     }

--- a/Sources/HTTPNetworking/Plugins/Adaptors/ZipAdaptor.swift
+++ b/Sources/HTTPNetworking/Plugins/Adaptors/ZipAdaptor.swift
@@ -5,7 +5,8 @@ public struct ZipAdaptor: HTTPRequestAdaptor {
     
     // MARK: Properties
     
-    let adaptors: [any HTTPRequestAdaptor]
+    /// An array of adaptors that make up this adaptor.
+    public let adaptors: [any HTTPRequestAdaptor]
     
     // MARK: Initializers
     

--- a/Sources/HTTPNetworking/Plugins/Adaptors/ZipAdaptor.swift
+++ b/Sources/HTTPNetworking/Plugins/Adaptors/ZipAdaptor.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - ZipAdaptor
+
 /// An ``HTTPRequestAdaptor`` that combines multiple adaptors into one, executing each adaptation in sequence.
 public struct ZipAdaptor: HTTPRequestAdaptor {
     
@@ -35,5 +37,15 @@ public struct ZipAdaptor: HTTPRequestAdaptor {
         }
         
         return request
+    }
+}
+
+// MARK: - HTTPRequest + ZipAdaptor
+
+extension HTTPRequest {
+    /// Applies a ``ZipAdaptor`` that bundles up all the provided adaptors.
+    @discardableResult
+    public func adapt(zipping adaptors: [any HTTPRequestAdaptor]) -> Self {
+        adapt(with: ZipAdaptor(adaptors))
     }
 }

--- a/Sources/HTTPNetworking/Plugins/HTTPRequestRetrier.swift
+++ b/Sources/HTTPNetworking/Plugins/HTTPRequestRetrier.swift
@@ -13,14 +13,14 @@ public protocol HTTPRequestRetrier {
         with response: HTTPURLResponse?,
         dueTo error: Error,
         previousAttempts: Int
-    ) async throws -> RetryStrategy
+    ) async throws -> RetryDecision
 }
 
-// MARK: - RetryStrategy
+// MARK: - RetryDecision
 
 /// A strategy that indicates to an ``HTTPRequest`` what approach should be taken when
 /// attempting to retry upon failure.
-public enum RetryStrategy {
+public enum RetryDecision {
     /// Indicates that a failing request should not be retried.
     case concede
     /// Indicates that a failing request should be reattempted.

--- a/Sources/HTTPNetworking/Plugins/HTTPRequestRetrier.swift
+++ b/Sources/HTTPNetworking/Plugins/HTTPRequestRetrier.swift
@@ -20,7 +20,7 @@ public protocol HTTPRequestRetrier {
 
 /// A strategy that indicates to an ``HTTPRequest`` what approach should be taken when
 /// attempting to retry upon failure.
-public enum RetryDecision {
+public enum RetryDecision: Equatable {
     /// Indicates that a failing request should not be retried.
     case concede
     /// Indicates that a failing request should be reattempted.

--- a/Sources/HTTPNetworking/Plugins/HTTPRequestRetrier.swift
+++ b/Sources/HTTPNetworking/Plugins/HTTPRequestRetrier.swift
@@ -7,7 +7,7 @@ import Foundation
 /// By conforming to ``HTTPRequestRetrier`` you can implement both simple and complex logic for retrying an ``HTTPRequest`` when
 /// it fails. Common uses cases include retrying a given amount of times due to a specific error such as poor network connectivity.
 public protocol HTTPRequestRetrier {
-    func retry(_ request: URLRequest, for session: URLSession, dueTo error: Error) async throws -> RetryStrategy
+    func retry(_ request: URLRequest, for session: URLSession, dueTo error: Error, previousAttempts: Int) async throws -> RetryStrategy
 }
 
 // MARK: - RetryStrategy

--- a/Sources/HTTPNetworking/Plugins/HTTPRequestRetrier.swift
+++ b/Sources/HTTPNetworking/Plugins/HTTPRequestRetrier.swift
@@ -7,7 +7,13 @@ import Foundation
 /// By conforming to ``HTTPRequestRetrier`` you can implement both simple and complex logic for retrying an ``HTTPRequest`` when
 /// it fails. Common uses cases include retrying a given amount of times due to a specific error such as poor network connectivity.
 public protocol HTTPRequestRetrier {
-    func retry(_ request: URLRequest, for session: URLSession, dueTo error: Error, previousAttempts: Int) async throws -> RetryStrategy
+    func retry(
+        _ request: URLRequest,
+        for session: URLSession,
+        with response: HTTPURLResponse?,
+        dueTo error: Error,
+        previousAttempts: Int
+    ) async throws -> RetryStrategy
 }
 
 // MARK: - RetryStrategy

--- a/Sources/HTTPNetworking/Plugins/HTTPResponseValidator.swift
+++ b/Sources/HTTPNetworking/Plugins/HTTPResponseValidator.swift
@@ -11,5 +11,5 @@ public typealias ValidationResult = Result<Void, Error>
 /// By conforming to ``HTTPResponseValidator`` you can implement both simple and complex logic for validating
 /// the response of an ``HTTPRequest``. Common use cases include validating the status code or headers of a response.
 public protocol HTTPResponseValidator {
-    func validate(_ response: HTTPURLResponse, for request: URLRequest, with data: Data) async throws -> ValidationResult
+    func validate(_ response: HTTPURLResponse, for request: URLRequest, with data: Data) async -> ValidationResult
 }

--- a/Sources/HTTPNetworking/Plugins/HTTPResponseValidator.swift
+++ b/Sources/HTTPNetworking/Plugins/HTTPResponseValidator.swift
@@ -1,6 +1,10 @@
 import Foundation
 
+// MARK: - ValidationResult
+
 public typealias ValidationResult = Result<Void, Error>
+
+// MARK: - HTTPResponseValidator
 
 /// An ``HTTPResponseValidator`` is used to validate the response from an ``HTTPRequest``.
 ///

--- a/Sources/HTTPNetworking/Plugins/Retriers/Retrier.swift
+++ b/Sources/HTTPNetworking/Plugins/Retriers/Retrier.swift
@@ -7,7 +7,7 @@ public struct Retrier: HTTPRequestRetrier {
     
     // MARK: Properties
     
-    let handler: RetryHandler
+    private let handler: RetryHandler
     
     // MARK: Initializers
     

--- a/Sources/HTTPNetworking/Plugins/Retriers/Retrier.swift
+++ b/Sources/HTTPNetworking/Plugins/Retriers/Retrier.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public typealias RetryHandler = (URLRequest, URLSession, Error) async -> RetryStrategy
+public typealias RetryHandler = (URLRequest, URLSession, Error, Int) async throws -> RetryStrategy
 
 /// An ``HTTPRequestRetrier`` that can be used to retry an ``HTTPRequest`` upon failure.
 public struct Retrier: HTTPRequestRetrier {
@@ -21,8 +21,13 @@ public struct Retrier: HTTPRequestRetrier {
     
     // MARK: ResponseValidator
     
-    public func retry(_ request: URLRequest, for session: URLSession, dueTo error: Error) async -> RetryStrategy {
-        await handler(request, session, error)
+    public func retry(
+        _ request: URLRequest,
+        for session: URLSession,
+        dueTo error: Error,
+        previousAttempts: Int
+    ) async throws -> RetryStrategy {
+        try await handler(request, session, error, previousAttempts)
     }
 }
 

--- a/Sources/HTTPNetworking/Plugins/Retriers/Retrier.swift
+++ b/Sources/HTTPNetworking/Plugins/Retriers/Retrier.swift
@@ -8,7 +8,7 @@ public typealias RetryHandler = (
     _ response: HTTPURLResponse?,
     _ error: Error,
     _ previousAttempts: Int
-) async throws -> RetryStrategy
+) async throws -> RetryDecision
 
 // MARK: - Retrier
 
@@ -37,7 +37,7 @@ public struct Retrier: HTTPRequestRetrier {
         with response: HTTPURLResponse?,
         dueTo error: Error,
         previousAttempts: Int
-    ) async throws -> RetryStrategy {
+    ) async throws -> RetryDecision {
         try await handler(request, session, response, error, previousAttempts)
     }
 }

--- a/Sources/HTTPNetworking/Plugins/Retriers/Retrier.swift
+++ b/Sources/HTTPNetworking/Plugins/Retriers/Retrier.swift
@@ -1,6 +1,12 @@
 import Foundation
 
-public typealias RetryHandler = (URLRequest, URLSession, Error, Int) async throws -> RetryStrategy
+public typealias RetryHandler = (
+    _ request: URLRequest,
+    _ session: URLSession,
+    _ response: HTTPURLResponse?,
+    _ error: Error,
+    _ previousAttempts: Int
+) async throws -> RetryStrategy
 
 /// An ``HTTPRequestRetrier`` that can be used to retry an ``HTTPRequest`` upon failure.
 public struct Retrier: HTTPRequestRetrier {
@@ -24,10 +30,11 @@ public struct Retrier: HTTPRequestRetrier {
     public func retry(
         _ request: URLRequest,
         for session: URLSession,
+        with response: HTTPURLResponse?,
         dueTo error: Error,
         previousAttempts: Int
     ) async throws -> RetryStrategy {
-        try await handler(request, session, error, previousAttempts)
+        try await handler(request, session, response, error, previousAttempts)
     }
 }
 

--- a/Sources/HTTPNetworking/Plugins/Retriers/Retrier.swift
+++ b/Sources/HTTPNetworking/Plugins/Retriers/Retrier.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - RetryHandler
+
 public typealias RetryHandler = (
     _ request: URLRequest,
     _ session: URLSession,
@@ -7,6 +9,8 @@ public typealias RetryHandler = (
     _ error: Error,
     _ previousAttempts: Int
 ) async throws -> RetryStrategy
+
+// MARK: - Retrier
 
 /// An ``HTTPRequestRetrier`` that can be used to retry an ``HTTPRequest`` upon failure.
 public struct Retrier: HTTPRequestRetrier {

--- a/Sources/HTTPNetworking/Plugins/Retriers/RetryStrategy.swift
+++ b/Sources/HTTPNetworking/Plugins/Retriers/RetryStrategy.swift
@@ -1,0 +1,387 @@
+import Foundation
+
+// MARK: - RetryStrategy
+
+/// An ``HTTPRequestRetrier`` that retries qualified requests based on provided HTTP methods, HTTP status codes and `URLError.Codes`
+/// Retries are triggered up to the provided number of attempts, and implement an exponential backoff approach with a jitter strategy.
+///
+/// > Tip: The default values provided for HTTP methods, HTTP status codes and `URLError.Codes` should be a solid starting ground for most
+/// netowrking clients. However, you can customize the configuration to tailor this retrier to your needs.
+open class RetryStrategy: HTTPRequestRetrier {
+    
+    // MARK: Constants
+    
+    public enum Constants {
+        
+        /// The default number of attempts a request should make to succed before conceding to failure.
+        public static let defaultAttempts: Int = 3
+        
+        /// The default methods for which to consider a retry.
+        ///
+        /// See [RFC 9110 - Section 9.2.2](https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods) for more information.
+        public static let defaultMethods: Set<HTTPMethod> = [.put, .delete, .get, .head, .options, .trace]
+        
+        /// The default status codes that should trigger a retry.
+        ///
+        /// See [RFC 9110 - Section 15](https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes) for more information.
+        public static let defaultStatusCodes: Set<Int> = [408, 500, 502, 503, 504]
+        
+        /// The default base of the exponential backoff in seconds.
+        public static let defaultExponentialBackoffBase: TimeInterval = 2
+        
+        /// The default jitter strategy for exponential backoff manipulation.
+        ///
+        /// See ``JitterStrategy`` for more information.
+        public static let defaultJitterStrategy: JitterStrategy = .full
+        
+        /// The default `URLError` codes that should trigger a retry.
+        ///
+        /// See [URLError.Code](https://developer.apple.com/documentation/foundation/urlerror/code) to learn more.
+        public static let defaultUrlErrorCodes: Set<URLError.Code> = [
+            // App Transport Security disallowed a connection because there is no secure network connection.
+            // [Disabled] - Cannot be changed at runtime.
+            // .appTransportSecurityRequiresSecureConnection,
+            
+            // An app or app extension attempted to connect to a background session that is already connected to a process.
+            // [Enabled] - Session could be released during a retry.
+            .backgroundSessionInUseByAnotherProcess,
+            
+            // The shared container identifier of the URL session configuration is needed but has not been set.
+            // [Disabled] - Cannot be changed at runtime.
+            //.backgroundSessionRequiresSharedContainer,
+            
+            // The app is suspended or exits while a background data task is processing.
+            // [Enabled] - App could return to the foreground or relaunch during a retry.
+            .backgroundSessionWasDisconnected,
+            
+            // The URL Loading system received bad data from the server.
+            // [Enabled] - The server could return valid data during a retry.
+            .badServerResponse,
+            
+            // A malformed URL prevented a URL request from being initiated.
+            // [Disabled] - Retrying a request with the a bad URL will likely still be bad.
+            //.badURL,
+            
+            // A connection was attempted while a phone call is active on a network that does not support
+            // simultaneous phone and data communication (EDGE or GPRS).
+            // [Enabled] - The phone call could end during a retry.
+            .callIsActive,
+            
+            // An asynchronous load has been canceled.
+            // [Disabled] - The request was explicitly cancelled.
+            //.cancelled,
+            
+            // A download task couldn’t close the downloaded file on disk.
+            // [Disabled] - Unlikely to recover from a FileSystem error.
+            //.cannotCloseFile,
+            
+            // An attempt to connect to a host failed.
+            // [Enabled] - Connection could succeed during a retry.
+            .cannotConnectToHost,
+            
+            // A download task couldn’t create the downloaded file on disk because of an I/O failure.
+            // [Disabled] - Unlikely to recover from a FileSystem error.
+            //.cannotCreateFile,
+            
+            // Content data received during a connection request had an unknown content encoding.
+            // [Disabled] - Unlikely to receive a different encoding of data by retrying.
+            //.cannotDecodeContentData,
+            
+            // Content data received during a connection request could not be decoded for a known content encoding.
+            // [Disabled] - Unlikely to receive a different encoding of data by retrying.
+            //.cannotDecodeRawData,
+            
+            // The host name for a URL could not be resolved.
+            // [Enabled] - The host could be resolved during a retry.
+            .cannotFindHost,
+            
+            // A request to load an item only from the cache could not be satisfied.
+            // [Enabled] - Cache could be updated during a retry.
+            .cannotLoadFromNetwork,
+            
+            // A download task was unable to move a downloaded file on disk.
+            // [Disabled] - Unlikely to recover from a FileSystem error.
+            //.cannotMoveFile,
+            
+            // A download task was unable to open the downloaded file on disk.
+            // [Disabled] - Unlikely to recover from a FileSystem error.
+            //.cannotOpenFile,
+            
+            // A task could not parse a response.
+            // [Disabled] - Unlikely to receive a different response by retrying.
+            //.cannotParseResponse,
+            
+            // A download task was unable to remove a downloaded file from disk.
+            // [Disabled] - Unlikely to recover from a FileSystem error.
+            //.cannotRemoveFile,
+            
+            // A download task was unable to write to the downloaded file on disk.
+            // [Disabled] - Unlikely to recover from a FileSystem error.
+            //.cannotWriteToFile,
+            
+            // A client certificate was rejected.
+            // [Disabled] - Unlikely to change during a retry.
+            //.clientCertificateRejected,
+            
+            // A client certificate was required to authenticate an SSL connection during a request.
+            // [Disabled] - Unlikely to change during a retry.
+            //.clientCertificateRequired,
+            
+            // The length of the resource data exceeds the maximum allowed.
+            // [Disabled] - Unlikely to change during a retry.
+            //.dataLengthExceedsMaximum,
+            
+            // The cellular network disallowed a connection.
+            // [Enabled] - Could connect to Wifi during a retry.
+            .dataNotAllowed,
+            
+            // The host address could not be found via DNS lookup.
+            // [Enabled] DNS lookup could succed during a retry.
+            .dnsLookupFailed,
+            
+            // A download task failed to decode an encoded file during the download.
+            // [Enabled] The stream encoding could change during a retry.
+            .downloadDecodingFailedMidStream,
+            
+            // A download task failed to decode an encoded file after downloading.
+            // [Enabled] The stream encoding could change during a retry.
+            .downloadDecodingFailedToComplete,
+            
+            // A file does not exist.
+            // [Disabled] - Unlikely to recover from a FileSystem error.
+            //.fileDoesNotExist,
+            
+            // A request for an FTP file resulted in the server responding that the file is not a plain file, but a directory.
+            // [Disabled] - Unlikely to recover from a FileSystem error.
+            //.fileIsDirectory,
+            
+            // A redirect loop has been detected or the threshold for number of allowable redirects has been exceeded (currently 16).
+            // [Disabled] - Unlikely to change during a retry.
+            //.httpTooManyRedirects,
+            
+            // The attempted connection required activating a data context while roaming, but international roaming is disabled.
+            // [Enabled] - Could connect to Wifi during a retry.
+            .internationalRoamingOff,
+            
+            // A client or server connection was severed in the middle of an in-progress load.
+            // [Enabled] - Could connect during a retry.
+            .networkConnectionLost,
+            
+            // A resource couldn’t be read because of insufficient permissions.
+            // [Disabled] - Unlikely to change during a retry.
+            //.noPermissionsToReadFile,
+            
+            // A network resource was requested, but an internet connection has not been established and cannot be established automatically.
+            // [Enabled] - Could connect during a retry.
+            .notConnectedToInternet,
+            
+            // A redirect was specified by way of server response code, but the server did not accompany this code with a redirect URL.
+            // [Disabled] - Unlikely to change during a retry.
+            //.redirectToNonExistentLocation,
+            
+            // A body stream is needed but the client did not provide one.
+            // [Disabled] - Unlikely to change during a retry.
+            //.requestBodyStreamExhausted,
+            
+            // A requested resource couldn’t be retrieved.
+            // [Disabled] - Unlikely to change during a retry.
+            //.resourceUnavailable,
+            
+            // An attempt to establish a secure connection failed for reasons that can’t be expressed more specifically.
+            // [Enabled] - Could connect during a retry.
+            .secureConnectionFailed,
+            
+            // A server certificate had a date which indicates it has expired, or is not yet valid.
+            // [Disabled] - Unlikely to change during a retry.
+            //.serverCertificateHasBadDate,
+            
+            // A server certificate was not signed by any root server.
+            // [Disabled] - Unlikely to change during a retry.
+            //.serverCertificateHasUnknownRoot,
+            
+            // A server certificate is not yet valid.
+            // [Disabled] - Unlikely to change during a retry.
+            //.serverCertificateNotYetValid,
+            
+            // A server certificate is not yet valid.
+            // [Disabled] - Unlikely to change during a retry.
+            //.serverCertificateUntrusted,
+            
+            // An asynchronous operation timed out.
+            // [Enabled] - Could succeed during a retry.
+            .timedOut,
+            
+            // The URL Loading System encountered an error that it can’t interpret.
+            // [Disabled] - Unlikely to change during a retry.
+            .unknown,
+            
+            // A properly formed URL couldn’t be handled by the framework.
+            // [Disabled] - Unlikely to change during a retry.
+            .unsupportedURL,
+            
+            // Authentication is required to access a resource.
+            // [Disabled] - Unlikely to change during a retry.
+            .userAuthenticationRequired,
+            
+            // An asynchronous request for authentication has been canceled by the user.
+            // [Disabled] - Unlikely to change during a retry.
+            .userCancelledAuthentication,
+            
+            // A server reported that a URL has a non-zero content length, but terminated the network connection gracefully without sending any data.
+            // [Disabled] - Unlikely to change during a retry.
+            .zeroByteResource,
+        ]
+    }
+    
+    // MARK: JitterStrategy
+    
+    /// Defines a strategy for backoff jitter.
+    ///
+    /// Given a multitude of clients interacting with a service at the same time, simply backing off does not solve the problem of dispersing a service's load over time,
+    /// it merely delays it. By adding jitter, we are able to better distribute the load over time, providing less contention for resources by competing clients.
+    ///
+    /// [Learn more about Exponential Backoff And Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)
+    public enum JitterStrategy {
+        /// A strategy that introduces no jitter into the backoff delay.
+        ///
+        /// Before Jitter: 5
+        /// After No Jitter: 5
+        case none
+        
+        /// A strategy that introduces randomness between half and full backoff delays.
+        ///
+        /// Before Jitter: `5`
+        /// After Equal Jitter: `Double.random(2.5...5)`
+        case equal
+        
+        /// A strategy that introduces full randomness between zero and the backoff delay.
+        ///
+        /// Before Jitter: `5`
+        /// After Full Jitter: `Double.random(0...5)`
+        case full
+        
+        /// Creates a new delay from the provided delay using the ``JitterStrategy``.
+        func jitter(for delay: TimeInterval) -> TimeInterval {
+            switch self {
+            case .none:
+                return delay
+            case .equal:
+                let half = delay / 2
+                return half + .random(in: 0...half)
+            case .full:
+                return TimeInterval.random(in: 0...delay)
+            }
+        }
+    }
+    
+    // MARK: Properties
+    
+    /// The total number of times a request should be allowed to retry.
+    public let attempts: Int
+    
+    /// The methods for which to consider a retry.
+    public let methods: Set<HTTPMethod>
+    
+    /// The `URLError.Codes` that should trigger a retry.
+    public let urlErrorCodes: Set<URLError.Code>
+    
+    /// The status codes that should trigger a retry.
+    public let statusCodes: Set<Int>
+    
+    /// The base of the exponential backoff in seconds.
+    ///
+    /// This number is the basis from which the backoff is calculated. That is, for each
+    /// retried attempt, the delay will scale this value exponentially.
+    public let exponentialBackoffBase: TimeInterval
+    
+    /// The jitter strategy to apply to the total delay duration.
+    public let jitterStrategy: JitterStrategy
+    
+    // MARK: Initializers
+    
+    public init(
+        attempts: Int = Constants.defaultAttempts,
+        methods: Set<HTTPMethod> = Constants.defaultMethods,
+        urlErrorCodes: Set<URLError.Code> = Constants.defaultUrlErrorCodes,
+        statusCodes: Set<Int> = Constants.defaultStatusCodes,
+        exponentialBackoffBase: TimeInterval = Constants.defaultExponentialBackoffBase,
+        jitterStrategy: JitterStrategy = Constants.defaultJitterStrategy
+    ) {
+        self.attempts = attempts
+        self.methods = methods
+        self.urlErrorCodes = urlErrorCodes
+        self.statusCodes = statusCodes
+        self.exponentialBackoffBase = exponentialBackoffBase
+        self.jitterStrategy = jitterStrategy
+    }
+    
+    // MARK: HTTPRequestRetrier
+    
+    public func retry(
+        _ request: URLRequest,
+        for session: URLSession,
+        with response: HTTPURLResponse?,
+        dueTo error: Error,
+        previousAttempts: Int
+    ) async throws -> RetryDecision {
+        if shouldRetry(request, for: session, with: response, dueTo: error, previousAttempts: previousAttempts) {
+            let base = Double(2)
+            let exponent = max(0, Double(previousAttempts - 1))
+            let delay = exponentialBackoffBase * pow(base, exponent)
+            return .retryAfterDelay(.seconds(jitterStrategy.jitter(for: delay)))
+        } else {
+            return .concede
+        }
+    }
+    
+    // MARK: Helpers
+    
+    /// Whether or not the request should be retried given the current state of the retrier.
+    open func shouldRetry(
+        _ request: URLRequest,
+        for session: URLSession,
+        with response: HTTPURLResponse?,
+        dueTo error: Error,
+        previousAttempts: Int
+    ) -> Bool {
+        guard
+            previousAttempts < attempts,
+            let method = request.httpMethod.flatMap({ HTTPMethod(rawValue: $0) }),
+            methods.contains(method)
+        else {
+            return false
+        }
+        
+        if let response, statusCodes.contains(response.statusCode) {
+            return true
+        } else if let error = error as? URLError, urlErrorCodes.contains(error.code) {
+            return true
+        } else {
+            return false
+        }
+    }
+}
+
+// MARK: - HTTPRequest + RetryStrategy
+
+extension HTTPRequest {
+    /// Applies a ``RetryStrategy`` with the provided configuration.
+    @discardableResult
+    public func retryStrategy(
+        attempts: Int = RetryStrategy.Constants.defaultAttempts,
+        methods: Set<HTTPMethod> = RetryStrategy.Constants.defaultMethods,
+        urlErrorCodes: Set<URLError.Code> = RetryStrategy.Constants.defaultUrlErrorCodes,
+        statusCodes: Set<Int> = RetryStrategy.Constants.defaultStatusCodes,
+        exponentialBackoffBase: TimeInterval = RetryStrategy.Constants.defaultExponentialBackoffBase,
+        jitterStrategy: RetryStrategy.JitterStrategy = RetryStrategy.Constants.defaultJitterStrategy
+    ) -> Self {
+        retry(with: RetryStrategy(
+            attempts: attempts,
+            methods: methods,
+            urlErrorCodes: urlErrorCodes,
+            statusCodes: statusCodes,
+            exponentialBackoffBase: exponentialBackoffBase,
+            jitterStrategy: jitterStrategy
+        ))
+    }
+}

--- a/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
+++ b/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
@@ -26,11 +26,22 @@ public struct ZipRetrier: HTTPRequestRetrier {
     
     // MARK: ResponseValidator
     
-    public func retry(_ request: URLRequest, for session: URLSession, dueTo error: Error) async throws -> RetryStrategy {
+    public func retry(
+        _ request: URLRequest,
+        for session: URLSession,
+        dueTo error: Error,
+        previousAttempts: Int
+    ) async throws -> RetryStrategy {
         for retrier in retriers {
             try Task.checkCancellation()
             
-            let strategy = try await retrier.retry(request, for: session, dueTo: error)
+            let strategy = try await retrier.retry(
+                request,
+                for: session,
+                dueTo: error,
+                previousAttempts: previousAttempts
+            )
+            
             switch strategy {
             case .concede:
                 continue

--- a/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
+++ b/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
@@ -29,6 +29,7 @@ public struct ZipRetrier: HTTPRequestRetrier {
     public func retry(
         _ request: URLRequest,
         for session: URLSession,
+        with response: HTTPURLResponse?,
         dueTo error: Error,
         previousAttempts: Int
     ) async throws -> RetryStrategy {
@@ -38,6 +39,7 @@ public struct ZipRetrier: HTTPRequestRetrier {
             let strategy = try await retrier.retry(
                 request,
                 for: session,
+                with: response,
                 dueTo: error,
                 previousAttempts: previousAttempts
             )

--- a/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
+++ b/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
@@ -34,7 +34,7 @@ public struct ZipRetrier: HTTPRequestRetrier {
         with response: HTTPURLResponse?,
         dueTo error: Error,
         previousAttempts: Int
-    ) async throws -> RetryStrategy {
+    ) async throws -> RetryDecision {
         for retrier in retriers {
             try Task.checkCancellation()
             

--- a/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
+++ b/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
@@ -5,7 +5,8 @@ public struct ZipRetrier: HTTPRequestRetrier {
     
     // MARK: Properties
     
-    let retriers: [any HTTPRequestRetrier]
+    /// An array of retriers that make up this retrier.
+    public let retriers: [any HTTPRequestRetrier]
     
     // MARK: Initializers
         

--- a/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
+++ b/Sources/HTTPNetworking/Plugins/Retriers/ZipRetrier.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - ZipRetrier
+
 /// An ``HTTPRequestRetrier`` that combines multiple retriers into one, executing each retrier in sequence.
 public struct ZipRetrier: HTTPRequestRetrier {
     
@@ -53,5 +55,15 @@ public struct ZipRetrier: HTTPRequestRetrier {
         }
         
         return .concede
+    }
+}
+
+// MARK: - HTTPRequest + ZipRetrier
+
+extension HTTPRequest {
+    /// Applies a ``ZipRetrier`` that bundles up all the provided retriers.
+    @discardableResult
+    public func retry(zipping retriers: [any HTTPRequestRetrier]) -> Self {
+        retry(with: ZipRetrier(retriers))
     }
 }

--- a/Sources/HTTPNetworking/Plugins/Validators/StatusCodeValidator.swift
+++ b/Sources/HTTPNetworking/Plugins/Validators/StatusCodeValidator.swift
@@ -15,7 +15,8 @@ public struct StatusCodeValidator<S: Sequence>: HTTPResponseValidator where S.It
     
     // MARK: Properties
     
-    let acceptableStatusCodes: S
+    /// The sequence of acceptable status codes for this validator.
+    public let acceptableStatusCodes: S
     
     // MARK: Initializers
     

--- a/Sources/HTTPNetworking/Plugins/Validators/Validator.swift
+++ b/Sources/HTTPNetworking/Plugins/Validators/Validator.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public typealias ValidationHandler = (HTTPURLResponse, URLRequest, Data) async -> ValidationResult
+public typealias ValidationHandler = (HTTPURLResponse, URLRequest, Data) async throws -> ValidationResult
 
 /// An ``HTTPResponseValidator`` that can be used to validate a response from an ``HTTPRequest``.
 public struct Validator: HTTPResponseValidator {
@@ -20,8 +20,8 @@ public struct Validator: HTTPResponseValidator {
     
     // MARK: HTTPResponseValidator
     
-    public func validate(_ response: HTTPURLResponse, for request: URLRequest, with data: Data) async -> ValidationResult {
-        await handler(response, request, data)
+    public func validate(_ response: HTTPURLResponse, for request: URLRequest, with data: Data) async throws -> ValidationResult {
+        try await handler(response, request, data)
     }
 }
 

--- a/Sources/HTTPNetworking/Plugins/Validators/Validator.swift
+++ b/Sources/HTTPNetworking/Plugins/Validators/Validator.swift
@@ -7,7 +7,7 @@ public struct Validator: HTTPResponseValidator {
     
     // MARK: Properties
     
-    let handler: ValidationHandler
+    private let handler: ValidationHandler
     
     // MARK: Initializers
     

--- a/Sources/HTTPNetworking/Plugins/Validators/Validator.swift
+++ b/Sources/HTTPNetworking/Plugins/Validators/Validator.swift
@@ -4,7 +4,7 @@ public typealias ValidationHandler = (
     _ response: HTTPURLResponse,
     _ request: URLRequest,
     _ data: Data
-) async throws -> ValidationResult
+) async -> ValidationResult
 
 /// An ``HTTPResponseValidator`` that can be used to validate a response from an ``HTTPRequest``.
 public struct Validator: HTTPResponseValidator {
@@ -24,8 +24,8 @@ public struct Validator: HTTPResponseValidator {
     
     // MARK: HTTPResponseValidator
     
-    public func validate(_ response: HTTPURLResponse, for request: URLRequest, with data: Data) async throws -> ValidationResult {
-        try await handler(response, request, data)
+    public func validate(_ response: HTTPURLResponse, for request: URLRequest, with data: Data) async -> ValidationResult {
+        await handler(response, request, data)
     }
 }
 

--- a/Sources/HTTPNetworking/Plugins/Validators/Validator.swift
+++ b/Sources/HTTPNetworking/Plugins/Validators/Validator.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-public typealias ValidationHandler = (HTTPURLResponse, URLRequest, Data) async throws -> ValidationResult
+public typealias ValidationHandler = (
+    _ response: HTTPURLResponse,
+    _ request: URLRequest,
+    _ data: Data
+) async throws -> ValidationResult
 
 /// An ``HTTPResponseValidator`` that can be used to validate a response from an ``HTTPRequest``.
 public struct Validator: HTTPResponseValidator {

--- a/Sources/HTTPNetworking/Plugins/Validators/ZipValidator.swift
+++ b/Sources/HTTPNetworking/Plugins/Validators/ZipValidator.swift
@@ -5,7 +5,8 @@ public struct ZipValidator: HTTPResponseValidator {
     
     // MARK: Properties
     
-    let validators: [any HTTPResponseValidator]
+    /// An array of validators that make up this validator.
+    public let validators: [any HTTPResponseValidator]
     
     // MARK: Initializers
     

--- a/Sources/HTTPNetworking/Plugins/Validators/ZipValidator.swift
+++ b/Sources/HTTPNetworking/Plugins/Validators/ZipValidator.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - ZipValidator
+
 /// An ``HTTPResponseValidator`` that combines multiple validators into one, executing each validation in sequence.
 public struct ZipValidator: HTTPResponseValidator {
     
@@ -36,5 +38,15 @@ public struct ZipValidator: HTTPResponseValidator {
         }
         
         return .success
+    }
+}
+
+// MARK: - HTTPRequest + ZipValidator
+
+extension HTTPRequest {
+    /// Applies a ``ZipValidator`` that bundles up all the provided validators.
+    @discardableResult
+    public func validate(zipping validators: [any HTTPResponseValidator]) -> Self {
+        validate(with: ZipValidator(validators))
     }
 }

--- a/Sources/HTTPNetworking/Plugins/Validators/ZipValidator.swift
+++ b/Sources/HTTPNetworking/Plugins/Validators/ZipValidator.swift
@@ -28,11 +28,12 @@ public struct ZipValidator: HTTPResponseValidator {
     
     // MARK: ResponseValidator
     
-    public func validate(_ response: HTTPURLResponse, for request: URLRequest, with data: Data) async throws -> ValidationResult {
+    public func validate(_ response: HTTPURLResponse, for request: URLRequest, with data: Data) async -> ValidationResult {
         for validator in validators {
-            try Task.checkCancellation()
+            do { try Task.checkCancellation() }
+            catch { return .failure(error) }
             
-            if case .failure(let error) = try await validator.validate(response, for: request, with: data) {
+            if case .failure(let error) = await validator.validate(response, for: request, with: data) {
                 return .failure(error)
             }
         }

--- a/Tests/ExtensionsTests/PublisherSinksTests.swift
+++ b/Tests/ExtensionsTests/PublisherSinksTests.swift
@@ -234,7 +234,7 @@ class PublisherSinksTests: XCTestCase {
         let emptyBagExpectation = createEmptyBagExpectation(from: bag)
 
         /// Perform test
-        var publisher: PassthroughSubject<String, MockError>? = .init()
+        let publisher: PassthroughSubject<String, MockError>? = .init()
         publisher?.sink(receiveValue: { value in
             XCTFail("Publisher should not have published a value.")
         }, receiveError: { error in

--- a/Tests/HTTPNetworkingTests/Extensions/URLRequest+Mock.swift
+++ b/Tests/HTTPNetworkingTests/Extensions/URLRequest+Mock.swift
@@ -1,5 +1,12 @@
 import Foundation
+import HTTPNetworking
 
 extension URLRequest {
     static let mock = URLRequest(url: .mock)
+    
+    static func mock(method: HTTPMethod) -> URLRequest {
+        var request = URLRequest(url: .mock)
+        request.httpMethod = method.rawValue
+        return request
+    }
 }

--- a/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
+++ b/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
@@ -624,7 +624,7 @@ class HTTPRequestTests: XCTestCase {
             ]),
             validators: [
                 Validator { _, _, _ in
-                    throw expectedError
+                    .failure(expectedError)
                 }
             ]
         )
@@ -652,7 +652,7 @@ class HTTPRequestTests: XCTestCase {
             _ = try await client
                 .request(for: .get, to: url, expecting: [String].self)
                 .validate { _, _, _ in
-                    throw expectedError
+                    .failure(expectedError)
                 }
                 .run()
         } catch {

--- a/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
+++ b/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
@@ -1104,7 +1104,7 @@ class HTTPRequestTests: XCTestCase {
         let retrierThreeExpectation = expectation(description: "Expected retrier three to retry.")
         let retrierFourExpectation = expectation(description: "Expected retrier four to retry.")
         
-        let block: (Int, Int, XCTestExpectation) -> RetryStrategy = { previousAttempts, expectedPreviousAttempts, expectation in
+        let block: (Int, Int, XCTestExpectation) -> RetryDecision = { previousAttempts, expectedPreviousAttempts, expectation in
             if previousAttempts == expectedPreviousAttempts {
                 expectation.fulfill()
                 return .retry

--- a/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
+++ b/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
@@ -107,7 +107,7 @@ class HTTPRequestTests: XCTestCase {
                 )
             ]),
             adaptors: [
-                Adaptor { request, session in
+                Adaptor { request, _ in
                     var request = request
                     request.setValue("TEST-HEADER", forHTTPHeaderField: "TEST-VALUE")
                     adaptedRequest = request
@@ -135,15 +135,15 @@ class HTTPRequestTests: XCTestCase {
                 url: .success(data: data, response: createResponse(for: url, with: 200))
             ]),
             adaptors: [
-                Adaptor { request, session in
+                Adaptor { request, _ in
                     adaptorOneExpectation.fulfill()
                     return request
                 },
-                Adaptor { request, session in
+                Adaptor { request, _ in
                     adaptorTwoExpectation.fulfill()
                     return request
                 },
-                Adaptor { request, session in
+                Adaptor { request, _ in
                     adaptorThreeExpectation.fulfill()
                     return request
                 }
@@ -181,7 +181,7 @@ class HTTPRequestTests: XCTestCase {
             ])
         )
         
-        let adaptor = Adaptor { request, session in
+        let adaptor = Adaptor { request, _ in
             var request = request
             request.setValue("TEST-HEADER", forHTTPHeaderField: "TEST-VALUE")
             adaptedRequest = request
@@ -211,15 +211,15 @@ class HTTPRequestTests: XCTestCase {
         
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
-            .adapt(with: Adaptor { request, session in
+            .adapt(with: Adaptor { request, _ in
                 adaptorOneExpectation.fulfill()
                 return request
             })
-            .adapt(with: Adaptor { request, session in
+            .adapt(with: Adaptor { request, _ in
                 adaptorTwoExpectation.fulfill()
                 return request
             })
-            .adapt(with: Adaptor { request, session in
+            .adapt(with: Adaptor { request, _ in
                 adaptorThreeExpectation.fulfill()
                 return request
             })
@@ -244,11 +244,11 @@ class HTTPRequestTests: XCTestCase {
                 url: .success(data: data, response: createResponse(for: url, with: 200))
             ]),
             adaptors: [
-                Adaptor { request, session in
+                Adaptor { request, _ in
                     adaptorOneExpectation.fulfill()
                     return request
                 },
-                Adaptor { request, session in
+                Adaptor { request, _ in
                     adaptorTwoExpectation.fulfill()
                     return request
                 }
@@ -257,11 +257,11 @@ class HTTPRequestTests: XCTestCase {
         
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
-            .adapt(with: Adaptor { request, session in
+            .adapt(with: Adaptor { request, _ in
                 adaptorThreeExpectation.fulfill()
                 return request
             })
-            .adapt(with: Adaptor { request, session in
+            .adapt(with: Adaptor { request, _ in
                 adaptorFourExpectation.fulfill()
                 return request
             })
@@ -273,6 +273,52 @@ class HTTPRequestTests: XCTestCase {
             adaptorThreeExpectation,
             adaptorFourExpectation
         ], enforceOrder: true)
+    }
+    
+    func test_client_whereAdaptorThrows_catchesExpectedError() async throws {
+        let url = createMockUrl()
+        let expectedError = MockError(id: 1)
+        
+        let client = HTTPClient(
+            dispatcher: .mock(responses: [
+                url: .success(data: data, response: createResponse(for: url, with: 200))
+            ]),
+            adaptors: [
+                Adaptor { _, _ in
+                    throw expectedError
+                }
+            ]
+        )
+        
+        do {
+            _ = try await client
+                .request(for: .get, to: url, expecting: [String].self)
+                .run()
+        } catch {
+            XCTAssertEqual(error as? MockError, expectedError)
+        }
+    }
+    
+    func test_request_whereAdaptorThrows_catchesExpectedError() async throws {
+        let url = createMockUrl()
+        let expectedError = MockError(id: 1)
+        
+        let client = HTTPClient(
+            dispatcher: .mock(responses: [
+                url: .success(data: data, response: createResponse(for: url, with: 200))
+            ])
+        )
+        
+        do {
+            _ = try await client
+                .request(for: .get, to: url, expecting: [String].self)
+                .adapt { _, _ in
+                    throw expectedError
+                }
+                .run()
+        } catch {
+            XCTAssertEqual(error as? MockError, expectedError)
+        }
     }
     
     // MARK: Validator Tests
@@ -292,7 +338,7 @@ class HTTPRequestTests: XCTestCase {
                 url: .success(data: data, response: expectedResponse)
             ]),
             validators: [
-                Validator { response, request, data in
+                Validator { response, _, _ in
                     let header = response.value(forHTTPHeaderField: "TEST-HEADER")
                     XCTAssertEqual(header, "TEST-VALUE")
                     validatorExpectation.fulfill()
@@ -319,7 +365,7 @@ class HTTPRequestTests: XCTestCase {
                 url: .success(data: data, response: createResponse(for: url,with: 200))
             ]),
             validators: [
-                Validator { response, request, data in
+                Validator { response, _, _ in
                     validatorExpectation.fulfill()
                     return .failure(expectedError)
                 }
@@ -350,11 +396,11 @@ class HTTPRequestTests: XCTestCase {
                 url: .success(data: data, response: createResponse(for: url,with: 200))
             ]),
             validators: [
-                Validator { response, request, data in
+                Validator { _, _, _ in
                     validatorOneExpectation.fulfill()
                     return .success
                 },
-                Validator { response, request, data in
+                Validator { _, _, _ in
                     validatorTwoExpectation.fulfill()
                     return .failure(expectedError)
                 }
@@ -384,11 +430,11 @@ class HTTPRequestTests: XCTestCase {
                 url: .success(data: data, response: createResponse(for: url,with: 200))
             ]),
             validators: [
-                Validator { response, request, data in
+                Validator { _, _, _ in
                     validatorOneExpectation.fulfill()
                     return .failure(expectedError)
                 },
-                Validator { response, request, data in
+                Validator { _, _, _ in
                     XCTFail("Expected previous validator to fail, ignoring this one.")
                     return .success
                 }
@@ -418,11 +464,11 @@ class HTTPRequestTests: XCTestCase {
                 url: .success(data: data, response: createResponse(for: url,with: 200))
             ]),
             validators: [
-                Validator { response, request, data in
+                Validator { _, _, _ in
                     validatorOneExpectation.fulfill()
                     return .failure(expectedError)
                 },
-                Validator { response, request, data in
+                Validator { _, _, _ in
                     XCTFail("Expected previous validator to fail, ignoring this one.")
                     return .failure(expectedError)
                 }
@@ -452,11 +498,11 @@ class HTTPRequestTests: XCTestCase {
                 url: .success(data: data, response: createResponse(for: url,with: 200))
             ]),
             validators: [
-                Validator { response, request, data in
+                Validator { _, _, _ in
                     validatorOneExpectation.fulfill()
                     return .success
                 },
-                Validator { response, request, data in
+                Validator { _, _, _ in
                     validatorTwoExpectation.fulfill()
                     return .success
                 }
@@ -487,7 +533,7 @@ class HTTPRequestTests: XCTestCase {
         
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
-            .validate(with: Validator { response, request, data in
+            .validate(with: Validator { _, _, _ in
                 validatorExpectation.fulfill()
                 return .success
             })
@@ -511,7 +557,7 @@ class HTTPRequestTests: XCTestCase {
         do {
             _ = try await client
                 .request(for: .get, to: url, expecting: [String].self)
-                .validate(with: Validator { response, request, data in
+                .validate(with: Validator { _, _, _ in
                     validatorExpectation.fulfill()
                     return .failure(expectedError)
                 })
@@ -537,11 +583,11 @@ class HTTPRequestTests: XCTestCase {
                 url: .success(data: data, response: createResponse(for: url, with: 200))
             ]),
             validators: [
-                Validator { response, request, data in
+                Validator { _, _, _ in
                     validatorOne.fulfill()
                     return .success
                 },
-                Validator { response, request, data in
+                Validator { _, _, _ in
                     validatorTwo.fulfill()
                     return .success
                 },
@@ -550,11 +596,11 @@ class HTTPRequestTests: XCTestCase {
         
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
-            .validate(with: Validator { response, request, data in
+            .validate(with: Validator { _, _, _ in
                 validatorThree.fulfill()
                 return .success
             })
-            .validate(with: Validator { response, request, data in
+            .validate(with: Validator { _, _, _ in
                 validatorFour.fulfill()
                 return .success
             })
@@ -566,6 +612,52 @@ class HTTPRequestTests: XCTestCase {
             validatorThree,
             validatorFour
         ], enforceOrder: true)
+    }
+    
+    func test_client_whereValidatorThrows_catchesExpectedError() async throws {
+        let url = createMockUrl()
+        let expectedError = MockError(id: 1)
+        
+        let client = HTTPClient(
+            dispatcher: .mock(responses: [
+                url: .success(data: data, response: createResponse(for: url, with: 200))
+            ]),
+            validators: [
+                Validator { _, _, _ in
+                    throw expectedError
+                }
+            ]
+        )
+        
+        do {
+            _ = try await client
+                .request(for: .get, to: url, expecting: [String].self)
+                .run()
+        } catch {
+            XCTAssertEqual(error as? MockError, expectedError)
+        }
+    }
+    
+    func test_request_whereValidatorThrows_catchesExpectedError() async throws {
+        let url = createMockUrl()
+        let expectedError = MockError(id: 1)
+        
+        let client = HTTPClient(
+            dispatcher: .mock(responses: [
+                url: .success(data: data, response: createResponse(for: url, with: 200))
+            ])
+        )
+        
+        do {
+            _ = try await client
+                .request(for: .get, to: url, expecting: [String].self)
+                .validate { _, _, _ in
+                    throw expectedError
+                }
+                .run()
+        } catch {
+            XCTAssertEqual(error as? MockError, expectedError)
+        }
     }
     
     // MARK: Retrier Tests
@@ -588,12 +680,12 @@ class HTTPRequestTests: XCTestCase {
                     } else {
                         return .success((self.data, self.createResponse(for: url, with: 200)))
                     }
-                }, onRecieveRequest: { request in
+                }, onRecieveRequest: { _ in
                     requestFiredExpectation.fulfill()
                 })
             ]),
             retriers: [
-                Retrier { request, session, error in
+                Retrier { _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retryExpectation.fulfill()
                     shouldRequestFail = false
@@ -623,7 +715,7 @@ class HTTPRequestTests: XCTestCase {
                 }),
             ]),
             retriers: [
-                Retrier { request, session, error in
+                Retrier { _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retryExpectation.fulfill()
                     return .concede
@@ -665,13 +757,13 @@ class HTTPRequestTests: XCTestCase {
                 })
             ]),
             retriers: [
-                Retrier { request, session, error in
+                Retrier { _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retryExpectation.fulfill()
                     shouldRequestFail = false
                     return .retry
                 },
-                Retrier { request, session, error in
+                Retrier { _, _, error, _ in
                     XCTFail("Second retrier should not have been called.")
                     return .concede
                 }
@@ -708,12 +800,12 @@ class HTTPRequestTests: XCTestCase {
                 })
             ]),
             retriers: [
-                Retrier { request, session, error in
+                Retrier { _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retrierOneExpectation.fulfill()
                     return .concede
                 },
-                Retrier { request, session, error in
+                Retrier { _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retrierTwoExpectation.fulfill()
                     shouldRequestFail = false
@@ -755,7 +847,7 @@ class HTTPRequestTests: XCTestCase {
         
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
-            .retry(with: Retrier { request, session, error in
+            .retry(with: Retrier { _, _, error, _ in
                 XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                 retryExpectation.fulfill()
                 shouldRequestFail = false
@@ -784,7 +876,7 @@ class HTTPRequestTests: XCTestCase {
         do {
             _ = try await client
                 .request(for: .get, to: url, expecting: [String].self)
-                .retry(with: Retrier { request, session, error in
+                .retry(with: Retrier { _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retryExpectation.fulfill()
                     return .concede
@@ -823,13 +915,13 @@ class HTTPRequestTests: XCTestCase {
         
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
-            .retry(with: Retrier { request, session, error in
+            .retry(with: Retrier { _, _, error, _ in
                 XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                 retryExpectation.fulfill()
                 shouldRequestFail = false
                 return .retry
             })
-            .retry(with: Retrier { request, session, error in
+            .retry(with: Retrier { _, _, error, _ in
                 XCTFail("Second retrier should not have been called.")
                 return .concede
             })
@@ -864,12 +956,12 @@ class HTTPRequestTests: XCTestCase {
         
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
-            .retry(with: Retrier { request, session, error in
+            .retry(with: Retrier { _, _, error, _ in
                 XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                 retrierOneExpectation.fulfill()
                 return .concede
             })
-            .retry(with: Retrier { request, session, error in
+            .retry(with: Retrier { _, _, error, _ in
                 XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                 retrierTwoExpectation.fulfill()
                 shouldRequestFail = false
@@ -893,11 +985,11 @@ class HTTPRequestTests: XCTestCase {
                 url: .failure(expectedError)
             ]),
             retriers: [
-                Retrier { request, session, error in
+                Retrier { _, _, error, _ in
                     retrierOneExpectation.fulfill()
                     return .concede
                 },
-                Retrier { request, session, error in
+                Retrier { _, _, error, _ in
                     retrierTwoExpectation.fulfill()
                     return .concede
                 }
@@ -907,11 +999,11 @@ class HTTPRequestTests: XCTestCase {
         do {
             _ = try await client
                 .request(for: .get, to: url, expecting: [String].self)
-                .retry(with: Retrier { request, session, error in
+                .retry(with: Retrier { _, _, error, _ in
                     retrierThreeExpectation.fulfill()
                     return .concede
                 })
-                .retry(with: Retrier { request, session, error in
+                .retry(with: Retrier { _, _, error, _ in
                     retrierFourExpectation.fulfill()
                     return .concede
                 })
@@ -947,12 +1039,12 @@ class HTTPRequestTests: XCTestCase {
                     } else {
                         return .success((self.data, self.createResponse(for: url, with: 200)))
                     }
-                }, onRecieveRequest: { request in
+                }, onRecieveRequest: { _ in
                     requestFiredExpectation.fulfill()
                 })
             ]),
             retriers: [
-                Retrier { request, session, error in
+                Retrier { _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retryExpectation.fulfill()
                     shouldRequestFail = false
@@ -986,7 +1078,7 @@ class HTTPRequestTests: XCTestCase {
                     } else {
                         return .success((self.data, self.createResponse(for: url, with: 200)))
                     }
-                }, onRecieveRequest: { request in
+                }, onRecieveRequest: { _ in
                     requestFiredExpectation.fulfill()
                 })
             ])
@@ -994,7 +1086,7 @@ class HTTPRequestTests: XCTestCase {
         
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
-            .retry { request, session, error in
+            .retry { _, _, error, _ in
                 XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                 retryExpectation.fulfill()
                 shouldRequestFail = false
@@ -1003,6 +1095,94 @@ class HTTPRequestTests: XCTestCase {
             .run()
         
         await fulfillment(of: [retryExpectation, requestFiredExpectation])
+    }
+    
+    func test_request_withMultipleRetriers_doesCorrectlyIncrementPreviousAttempts() async throws {
+        let url = createMockUrl()
+        let retrierOneExpectation = expectation(description: "Expected retrier one to retry.")
+        let retrierTwoExpectation = expectation(description: "Expected retrier two to retry.")
+        let retrierThreeExpectation = expectation(description: "Expected retrier three to retry.")
+        let retrierFourExpectation = expectation(description: "Expected retrier four to retry.")
+        
+        let block: (Int, Int, XCTestExpectation) -> RetryStrategy = { previousAttempts, expectedPreviousAttempts, expectation in
+            if previousAttempts == expectedPreviousAttempts {
+                expectation.fulfill()
+                return .retry
+            } else {
+                return .concede
+            }
+        }
+        
+        let client = HTTPClient(
+            dispatcher: .mock(responses: [
+                url: .failure(URLError(.cannotConnectToHost))
+            ]),
+            retriers: [
+                Retrier {
+                    block($3, 1, retrierOneExpectation)
+                },
+                Retrier { block($3, 2, retrierTwoExpectation) },
+            ]
+        )
+        
+        do {
+            _ = try await client
+                .request(for: .get, to: url, expecting: [String].self)
+                .retry { block($3, 3, retrierThreeExpectation) }
+                .retry { block($3, 4, retrierFourExpectation) }
+                .run()
+            XCTFail("Expected request to fail.")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .cannotConnectToHost)
+        }
+        
+        await fulfillment(of: [retrierOneExpectation, retrierTwoExpectation, retrierThreeExpectation, retrierFourExpectation], enforceOrder: true)
+    }
+    
+    func test_client_whereRetrierThrows_catchesExpectedError() async throws {
+        let url = createMockUrl()
+        let expectedError = MockError(id: 1)
+        
+        let client = HTTPClient(
+            dispatcher: .mock(responses: [
+                url: .success(data: data, response: createResponse(for: url, with: 200))
+            ]),
+            retriers: [
+                Retrier { _, _, _, _ in
+                    throw expectedError
+                }
+            ]
+        )
+        
+        do {
+            _ = try await client
+                .request(for: .get, to: url, expecting: [String].self)
+                .run()
+        } catch {
+            XCTAssertEqual(error as? MockError, expectedError)
+        }
+    }
+    
+    func test_request_whereRetrierThrows_catchesExpectedError() async throws {
+        let url = createMockUrl()
+        let expectedError = MockError(id: 1)
+        
+        let client = HTTPClient(
+            dispatcher: .mock(responses: [
+                url: .success(data: data, response: createResponse(for: url, with: 200))
+            ])
+        )
+        
+        do {
+            _ = try await client
+                .request(for: .get, to: url, expecting: [String].self)
+                .retry { _, _, _, _ in
+                    throw expectedError
+                }
+                .run()
+        } catch {
+            XCTAssertEqual(error as? MockError, expectedError)
+        }
     }
     
     // MARK: Task Cancellation Tests
@@ -1038,7 +1218,7 @@ class HTTPRequestTests: XCTestCase {
                 }
             ],
             retriers: [
-                Retrier { _, _, _ in
+                Retrier { _, _, _, _ in
                     XCTFail("Retrier should not have been called after task cancellation.")
                     return .concede
                 }
@@ -1081,7 +1261,7 @@ class HTTPRequestTests: XCTestCase {
                 }
             ],
             retriers: [
-                Retrier { _, _, _ in
+                Retrier { _, _, _, _ in
                     XCTFail("Retrier should not have been called after task cancellation.")
                     return .concede
                 }
@@ -1114,11 +1294,11 @@ class HTTPRequestTests: XCTestCase {
                 )
             ]),
             retriers: [
-                Retrier { _, _, _ in
+                Retrier { _, _, _, _ in
                     task?.cancel()
                     return .concede
                 },
-                Retrier { _, _, _ in
+                Retrier { _, _, _, _ in
                     XCTFail("Second retrier should not have been called after task cancellation.")
                     return .concede
                 },

--- a/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
+++ b/Tests/HTTPNetworkingTests/HTTPRequestTests.swift
@@ -685,7 +685,7 @@ class HTTPRequestTests: XCTestCase {
                 })
             ]),
             retriers: [
-                Retrier { _, _, error, _ in
+                Retrier { _, _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retryExpectation.fulfill()
                     shouldRequestFail = false
@@ -715,7 +715,7 @@ class HTTPRequestTests: XCTestCase {
                 }),
             ]),
             retriers: [
-                Retrier { _, _, error, _ in
+                Retrier { _, _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retryExpectation.fulfill()
                     return .concede
@@ -757,13 +757,13 @@ class HTTPRequestTests: XCTestCase {
                 })
             ]),
             retriers: [
-                Retrier { _, _, error, _ in
+                Retrier { _, _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retryExpectation.fulfill()
                     shouldRequestFail = false
                     return .retry
                 },
-                Retrier { _, _, error, _ in
+                Retrier { _, _, _, error, _ in
                     XCTFail("Second retrier should not have been called.")
                     return .concede
                 }
@@ -800,12 +800,12 @@ class HTTPRequestTests: XCTestCase {
                 })
             ]),
             retriers: [
-                Retrier { _, _, error, _ in
+                Retrier { _, _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retrierOneExpectation.fulfill()
                     return .concede
                 },
-                Retrier { _, _, error, _ in
+                Retrier { _, _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retrierTwoExpectation.fulfill()
                     shouldRequestFail = false
@@ -847,7 +847,7 @@ class HTTPRequestTests: XCTestCase {
         
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
-            .retry(with: Retrier { _, _, error, _ in
+            .retry(with: Retrier { _, _, _, error, _ in
                 XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                 retryExpectation.fulfill()
                 shouldRequestFail = false
@@ -876,7 +876,7 @@ class HTTPRequestTests: XCTestCase {
         do {
             _ = try await client
                 .request(for: .get, to: url, expecting: [String].self)
-                .retry(with: Retrier { _, _, error, _ in
+                .retry(with: Retrier { _, _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retryExpectation.fulfill()
                     return .concede
@@ -915,13 +915,13 @@ class HTTPRequestTests: XCTestCase {
         
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
-            .retry(with: Retrier { _, _, error, _ in
+            .retry(with: Retrier { _, _, _, error, _ in
                 XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                 retryExpectation.fulfill()
                 shouldRequestFail = false
                 return .retry
             })
-            .retry(with: Retrier { _, _, error, _ in
+            .retry(with: Retrier { _, _, _, error, _ in
                 XCTFail("Second retrier should not have been called.")
                 return .concede
             })
@@ -956,12 +956,12 @@ class HTTPRequestTests: XCTestCase {
         
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
-            .retry(with: Retrier { _, _, error, _ in
+            .retry(with: Retrier { _, _, _, error, _ in
                 XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                 retrierOneExpectation.fulfill()
                 return .concede
             })
-            .retry(with: Retrier { _, _, error, _ in
+            .retry(with: Retrier { _, _, _, error, _ in
                 XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                 retrierTwoExpectation.fulfill()
                 shouldRequestFail = false
@@ -985,11 +985,11 @@ class HTTPRequestTests: XCTestCase {
                 url: .failure(expectedError)
             ]),
             retriers: [
-                Retrier { _, _, error, _ in
+                Retrier { _, _, _, error, _ in
                     retrierOneExpectation.fulfill()
                     return .concede
                 },
-                Retrier { _, _, error, _ in
+                Retrier { _, _, _, error, _ in
                     retrierTwoExpectation.fulfill()
                     return .concede
                 }
@@ -999,11 +999,11 @@ class HTTPRequestTests: XCTestCase {
         do {
             _ = try await client
                 .request(for: .get, to: url, expecting: [String].self)
-                .retry(with: Retrier { _, _, error, _ in
+                .retry(with: Retrier { _, _, _, error, _ in
                     retrierThreeExpectation.fulfill()
                     return .concede
                 })
-                .retry(with: Retrier { _, _, error, _ in
+                .retry(with: Retrier { _, _, _, error, _ in
                     retrierFourExpectation.fulfill()
                     return .concede
                 })
@@ -1044,7 +1044,7 @@ class HTTPRequestTests: XCTestCase {
                 })
             ]),
             retriers: [
-                Retrier { _, _, error, _ in
+                Retrier { _, _, _, error, _ in
                     XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                     retryExpectation.fulfill()
                     shouldRequestFail = false
@@ -1086,7 +1086,7 @@ class HTTPRequestTests: XCTestCase {
         
         _ = try await client
             .request(for: .get, to: url, expecting: [String].self)
-            .retry { _, _, error, _ in
+            .retry { _, _, _, error, _ in
                 XCTAssertEqual((error as? URLError)?.code, expectedError.code)
                 retryExpectation.fulfill()
                 shouldRequestFail = false
@@ -1119,17 +1119,17 @@ class HTTPRequestTests: XCTestCase {
             ]),
             retriers: [
                 Retrier {
-                    block($3, 1, retrierOneExpectation)
+                    block($4, 1, retrierOneExpectation)
                 },
-                Retrier { block($3, 2, retrierTwoExpectation) },
+                Retrier { block($4, 2, retrierTwoExpectation) },
             ]
         )
         
         do {
             _ = try await client
                 .request(for: .get, to: url, expecting: [String].self)
-                .retry { block($3, 3, retrierThreeExpectation) }
-                .retry { block($3, 4, retrierFourExpectation) }
+                .retry { block($4, 3, retrierThreeExpectation) }
+                .retry { block($4, 4, retrierFourExpectation) }
                 .run()
             XCTFail("Expected request to fail.")
         } catch {
@@ -1148,7 +1148,7 @@ class HTTPRequestTests: XCTestCase {
                 url: .success(data: data, response: createResponse(for: url, with: 200))
             ]),
             retriers: [
-                Retrier { _, _, _, _ in
+                Retrier { _, _, _, _, _ in
                     throw expectedError
                 }
             ]
@@ -1176,7 +1176,7 @@ class HTTPRequestTests: XCTestCase {
         do {
             _ = try await client
                 .request(for: .get, to: url, expecting: [String].self)
-                .retry { _, _, _, _ in
+                .retry { _, _, _, _, _ in
                     throw expectedError
                 }
                 .run()
@@ -1218,7 +1218,7 @@ class HTTPRequestTests: XCTestCase {
                 }
             ],
             retriers: [
-                Retrier { _, _, _, _ in
+                Retrier { _, _, _, _, _ in
                     XCTFail("Retrier should not have been called after task cancellation.")
                     return .concede
                 }
@@ -1261,7 +1261,7 @@ class HTTPRequestTests: XCTestCase {
                 }
             ],
             retriers: [
-                Retrier { _, _, _, _ in
+                Retrier { _, _, _, _, _ in
                     XCTFail("Retrier should not have been called after task cancellation.")
                     return .concede
                 }
@@ -1294,11 +1294,11 @@ class HTTPRequestTests: XCTestCase {
                 )
             ]),
             retriers: [
-                Retrier { _, _, _, _ in
+                Retrier { _, _, _, _, _ in
                     task?.cancel()
                     return .concede
                 },
-                Retrier { _, _, _, _ in
+                Retrier { _, _, _, _, _ in
                     XCTFail("Second retrier should not have been called after task cancellation.")
                     return .concede
                 },

--- a/Tests/HTTPNetworkingTests/Plugins/Retriers/RetrierTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Retriers/RetrierTests.swift
@@ -8,12 +8,17 @@ class RetrierTests: XCTestCase {
         let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectation = expectation(description: "Expected handler to be called.")
    
-        let retrier = Retrier { _, _, _ in
+        let retrier = Retrier { _, _, _, _ in
             expectation.fulfill()
             return .concede
         }
     
-        _ = await retrier.retry(request.request, for: .shared, dueTo: URLError(.cannotParseResponse))
+        _ = try await retrier.retry(
+            request.request,
+            for: .shared,
+            dueTo: URLError(.cannotParseResponse),
+            previousAttempts: 0
+        )
         await fulfillment(of: [expectation])
     }
     
@@ -23,7 +28,7 @@ class RetrierTests: XCTestCase {
         let client = HTTPClient()
         let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectation = expectation(description: "Expected retrier to be called.")
-        request.retry { _, _, _ in
+        request.retry { _, _, _, _ in
             expectation.fulfill()
             return .concede
         }
@@ -31,7 +36,8 @@ class RetrierTests: XCTestCase {
         _ = try await request.retriers.first?.retry(
             request.request,
             for: client.dispatcher.session,
-            dueTo: MockError()
+            dueTo: MockError(),
+            previousAttempts: 0
         )
         
         await fulfillment(of: [expectation])

--- a/Tests/HTTPNetworkingTests/Plugins/Retriers/RetrierTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Retriers/RetrierTests.swift
@@ -8,7 +8,7 @@ class RetrierTests: XCTestCase {
         let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectation = expectation(description: "Expected handler to be called.")
    
-        let retrier = Retrier { _, _, _, _ in
+        let retrier = Retrier { _, _, _, _, _ in
             expectation.fulfill()
             return .concede
         }
@@ -16,6 +16,7 @@ class RetrierTests: XCTestCase {
         _ = try await retrier.retry(
             request.request,
             for: .shared,
+            with: nil,
             dueTo: URLError(.cannotParseResponse),
             previousAttempts: 0
         )
@@ -28,7 +29,7 @@ class RetrierTests: XCTestCase {
         let client = HTTPClient()
         let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectation = expectation(description: "Expected retrier to be called.")
-        request.retry { _, _, _, _ in
+        request.retry { _, _, _, _, _ in
             expectation.fulfill()
             return .concede
         }
@@ -36,6 +37,7 @@ class RetrierTests: XCTestCase {
         _ = try await request.retriers.first?.retry(
             request.request,
             for: client.dispatcher.session,
+            with: nil,
             dueTo: MockError(),
             previousAttempts: 0
         )

--- a/Tests/HTTPNetworkingTests/Plugins/Retriers/RetryStrategyTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Retriers/RetryStrategyTests.swift
@@ -1,0 +1,283 @@
+@testable import HTTPNetworking
+import XCTest
+
+class RetryStrategyTests: XCTestCase {
+    func test_retryStrategy_whereMethodMatchesAndErrorMatchesAndStatusMatches_shouldRetry() async throws {
+        let strategy = RetryStrategy(
+            attempts: 3,
+            methods: [.get],
+            urlErrorCodes: [.networkConnectionLost],
+            statusCodes: [418],
+            exponentialBackoffBase: 1,
+            jitterStrategy: .none
+        )
+        
+        let decision = try await strategy.retry(
+            .mock(method: .get),
+            for: .shared,
+            with: HTTPURLResponse(url: .mock, statusCode: 418, httpVersion: nil, headerFields: nil),
+            dueTo: URLError(.networkConnectionLost),
+            previousAttempts: 0
+        )
+        
+        XCTAssertEqual(decision, .retryAfterDelay(.seconds(1)))
+    }
+    
+    func test_retryStrategy_whereMethodMatchesAndErrorMatchesAndStatusDoesNotMatch_shouldRetry() async throws {
+        let strategy = RetryStrategy(
+            attempts: 3,
+            methods: [.get],
+            urlErrorCodes: [.networkConnectionLost],
+            statusCodes: [],
+            exponentialBackoffBase: 1,
+            jitterStrategy: .none
+        )
+        
+        let decision = try await strategy.retry(
+            .mock(method: .get),
+            for: .shared,
+            with: nil,
+            dueTo: URLError(.networkConnectionLost),
+            previousAttempts: 0
+        )
+        
+        XCTAssertEqual(decision, .retryAfterDelay(.seconds(1)))
+    }
+    
+    func test_retryStrategy_whereMethodMatchesAndErrorDoesNotMatchAndStatusMatches_shouldRetry() async throws {
+        let strategy = RetryStrategy(
+            attempts: 3,
+            methods: [.get],
+            urlErrorCodes: [],
+            statusCodes: [418],
+            exponentialBackoffBase: 1,
+            jitterStrategy: .none
+        )
+        
+        let decision = try await strategy.retry(
+            .mock(method: .get),
+            for: .shared,
+            with: HTTPURLResponse(url: .mock, statusCode: 418, httpVersion: nil, headerFields: nil),
+            dueTo: URLError(.networkConnectionLost),
+            previousAttempts: 0
+        )
+        
+        XCTAssertEqual(decision, .retryAfterDelay(.seconds(1)))
+    }
+    
+    func test_retryStrategy_whereMethodDoesNotMatchAndErrorMatchesAndStatusMatches_shouldConcede() async throws {
+        let strategy = RetryStrategy(
+            attempts: 3,
+            methods: [],
+            urlErrorCodes: [.networkConnectionLost],
+            statusCodes: [418],
+            exponentialBackoffBase: 1,
+            jitterStrategy: .none
+        )
+        
+        let decision = try await strategy.retry(
+            .mock(method: .get),
+            for: .shared,
+            with: HTTPURLResponse(url: .mock, statusCode: 418, httpVersion: nil, headerFields: nil),
+            dueTo: URLError(.networkConnectionLost),
+            previousAttempts: 0
+        )
+        
+        XCTAssertEqual(decision, .concede)
+    }
+    
+    func test_retryStrategy_whereMethodDoesNotMatchAndErrorDoesNotMatchAndStatusMatches_shouldConcded() async throws {
+        let strategy = RetryStrategy(
+            attempts: 3,
+            methods: [],
+            urlErrorCodes: [],
+            statusCodes: [418],
+            exponentialBackoffBase: 1,
+            jitterStrategy: .none
+        )
+        
+        let decision = try await strategy.retry(
+            .mock(method: .get),
+            for: .shared,
+            with: HTTPURLResponse(url: .mock, statusCode: 418, httpVersion: nil, headerFields: nil),
+            dueTo: URLError(.networkConnectionLost),
+            previousAttempts: 0
+        )
+        
+        XCTAssertEqual(decision, .concede)
+    }
+    
+    func test_retryStrategy_whereMethodDoesNotMatchAndErrorMatchesAndStatusDoesNotMatch_shouldConcede() async throws {
+        let strategy = RetryStrategy(
+            attempts: 3,
+            methods: [],
+            urlErrorCodes: [.networkConnectionLost],
+            statusCodes: [],
+            exponentialBackoffBase: 1,
+            jitterStrategy: .none
+        )
+        
+        let decision = try await strategy.retry(
+            .mock(method: .get),
+            for: .shared,
+            with: HTTPURLResponse(url: .mock, statusCode: 418, httpVersion: nil, headerFields: nil),
+            dueTo: URLError(.networkConnectionLost),
+            previousAttempts: 0
+        )
+        
+        XCTAssertEqual(decision, .concede)
+    }
+    
+    func test_retryStrategy_whereMethodMatchesAndErrorDoesNotMatchAndStatusDoesNotMatch_shouldConcdede() async throws {
+        let strategy = RetryStrategy(
+            attempts: 3,
+            methods: [.get],
+            urlErrorCodes: [],
+            statusCodes: [],
+            exponentialBackoffBase: 1,
+            jitterStrategy: .none
+        )
+        
+        let decision = try await strategy.retry(
+            .mock(method: .get),
+            for: .shared,
+            with: HTTPURLResponse(url: .mock, statusCode: 418, httpVersion: nil, headerFields: nil),
+            dueTo: URLError(.networkConnectionLost),
+            previousAttempts: 0
+        )
+        
+        XCTAssertEqual(decision, .concede)
+    }
+    
+    func test_retryStrategy_whereMethodDoesNotMatchAndErrorDoesNotMatchAndStatusDoesNotMatch_shouldConcede() async throws {
+        let strategy = RetryStrategy(
+            attempts: 3,
+            methods: [],
+            urlErrorCodes: [],
+            statusCodes: [],
+            exponentialBackoffBase: 1,
+            jitterStrategy: .none
+        )
+        
+        let decision = try await strategy.retry(
+            .mock(method: .get),
+            for: .shared,
+            with: HTTPURLResponse(url: .mock, statusCode: 418, httpVersion: nil, headerFields: nil),
+            dueTo: URLError(.networkConnectionLost),
+            previousAttempts: 0
+        )
+        
+        XCTAssertEqual(decision, .concede)
+    }
+    
+    func test_retryStrategy_shouldRetryButAttemptsIsAtTheLimit_shouldConcdede() async throws {
+        let strategy = RetryStrategy(
+            attempts: 1,
+            methods: [.get],
+            urlErrorCodes: [.networkConnectionLost],
+            statusCodes: [418],
+            exponentialBackoffBase: 1,
+            jitterStrategy: .none
+        )
+        
+        let decision = try await strategy.retry(
+            .mock(method: .get),
+            for: .shared,
+            with: HTTPURLResponse(url: .mock, statusCode: 418, httpVersion: nil, headerFields: nil),
+            dueTo: URLError(.networkConnectionLost),
+            previousAttempts: 1
+        )
+        
+        XCTAssertEqual(decision, .concede)
+    }
+    
+    func test_retryStrategy_shouldRetryButAttemptsIsGreaterThanTheLimit_shouldConcdede() async throws {
+        let strategy = RetryStrategy(
+            attempts: 1,
+            methods: [.get],
+            urlErrorCodes: [.networkConnectionLost],
+            statusCodes: [418],
+            exponentialBackoffBase: 1,
+            jitterStrategy: .none
+        )
+        
+        let decision = try await strategy.retry(
+            .mock(method: .get),
+            for: .shared,
+            with: HTTPURLResponse(url: .mock, statusCode: 418, httpVersion: nil, headerFields: nil),
+            dueTo: URLError(.networkConnectionLost),
+            previousAttempts: 2
+        )
+        
+        XCTAssertEqual(decision, .concede)
+    }
+    
+    func test_retryStrategy_exponentialBackOff_increasesWithEachRetry() async throws {
+        let strategy = RetryStrategy(
+            attempts: 5,
+            methods: [.get],
+            urlErrorCodes: [.networkConnectionLost],
+            statusCodes: [418],
+            exponentialBackoffBase: 2,
+            jitterStrategy: .none
+        )
+        
+        let expectedDelays = [2, 4, 8, 16]
+        for index in 0...3 {
+            let decision = try await strategy.retry(
+                .mock(method: .get),
+                for: .shared,
+                with: HTTPURLResponse(url: .mock, statusCode: 418, httpVersion: nil, headerFields: nil),
+                dueTo: URLError(.networkConnectionLost),
+                previousAttempts: index + 1
+            )
+         
+            print(decision)
+            XCTAssertEqual(decision, .retryAfterDelay(.seconds(expectedDelays[index])))
+        }
+    }
+    
+    func test_none_jitterStrategyJitter_returnsUntouchedDuration() {
+        let jitter = RetryStrategy.JitterStrategy.none.jitter(for: 1)
+        XCTAssertEqual(jitter, 1)
+    }
+    
+    func test_full_jitterStrategyJitter_returnsDurationBetweenZeroAndProvidedDuration() {
+        for _ in 0...999 {
+            let jitter = RetryStrategy.JitterStrategy.full.jitter(for: 5)
+            XCTAssertTrue((0...5).contains(jitter))
+        }
+    }
+    
+    func test_equal_jitterStrategyJitter_returnsDurationBetweenHalfDurationAndProvidedDuration() {
+        for _ in 0...999 {
+            let jitter = RetryStrategy.JitterStrategy.equal.jitter(for: 5)
+            XCTAssertTrue((2.5...5).contains(jitter))
+        }
+    }
+    
+    func test_retryStrategy_retrierConvenience_isAddedToRequestRetriers() async throws {
+        let client = HTTPClient(dispatcher: .mock(responses: [.mock: .failure(URLError(.badURL))]))
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
+        request.retryStrategy(
+            attempts: 999,
+            methods: [.get],
+            urlErrorCodes: [.badURL],
+            statusCodes: [401],
+            exponentialBackoffBase: 1,
+            jitterStrategy: .full
+        )
+        
+        guard let retrier = request.retriers.first as? RetryStrategy else {
+            XCTFail("Expected first retrier to be a RetryStrategy.")
+            return
+        }
+        
+        XCTAssertEqual(retrier.attempts, 999)
+        XCTAssertEqual(retrier.methods, [.get])
+        XCTAssertEqual(retrier.urlErrorCodes, [.badURL])
+        XCTAssertEqual(retrier.statusCodes, [401])
+        XCTAssertEqual(retrier.exponentialBackoffBase, 1)
+        XCTAssertEqual(retrier.jitterStrategy, .full)
+    }
+}

--- a/Tests/HTTPNetworkingTests/Plugins/Retriers/ZipRetrierTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Retriers/ZipRetrierTests.swift
@@ -11,7 +11,7 @@ class ZipRetrierTests: XCTestCase {
                 with response: HTTPURLResponse?,
                 dueTo error: Error,
                 previousAttempts: Int
-            ) async -> HTTPNetworking.RetryStrategy {
+            ) async -> HTTPNetworking.RetryDecision {
                 .concede
             }
         }

--- a/Tests/HTTPNetworkingTests/Plugins/Validators/ValidatorTests.swift
+++ b/Tests/HTTPNetworkingTests/Plugins/Validators/ValidatorTests.swift
@@ -12,7 +12,7 @@ class ValidatorTests: XCTestCase {
             return .success
         }
     
-        _ = await validator.validate(HTTPURLResponse(), for: request.request, with: Data())
+        _ = try await validator.validate(HTTPURLResponse(), for: request.request, with: Data())
         await fulfillment(of: [expectation])
     }
     


### PR DESCRIPTION
Resolves #10 

- Improves documentation for various `HTTPNetworking` plugins and types.
- Adds `HTTPURLResponse?` to retriers.
- Adds convenience request modifiers for all zip plugins.
- Removes throwing from validator to avoid confusion as it already takes a `Result` type.
- Rename `RetryStrategy` to `RetryDecision` to allow the name to be used for the sample retrier.
- Adds sample retrier for most networking use cases.