### PR TITLE
♻️ Converts HTTPRequest to be a struct instead of a class.

### DIFF
--- a/Sources/Exchange/HTTP/HTTPClient.swift
+++ b/Sources/Exchange/HTTP/HTTPClient.swift
@@ -89,22 +89,22 @@ public struct HTTPClient {
     // MARK: Properties
     
     /// The encoder that each request uses to encode request bodies.
-    public let encoder: JSONEncoder
+    public var encoder: JSONEncoder
     
     /// The decoder that each request uses to decode response bodies.
-    public let decoder: JSONDecoder
+    public var decoder: JSONDecoder
     
     /// The dispatcher that sends out each request.
-    public let dispatcher: HTTPDispatcher
+    public var dispatcher: HTTPDispatcher
     
     /// A collection of adaptors that adapt each request.
-    public let adaptors: [any HTTPRequestAdaptor]
+    public var adaptors: [any HTTPRequestAdaptor]
     
     /// A collection of validators that validate each response.
-    public let validators: [any HTTPResponseValidator]
+    public var validators: [any HTTPResponseValidator]
     
     /// A collection of retriers that handle retrying failed requests.
-    public let retriers: [any HTTPRequestRetrier]
+    public var retriers: [any HTTPRequestRetrier]
     
     // MARK: Initializers
     
@@ -133,7 +133,7 @@ public struct HTTPClient {
         self.validators = validators
     }
     
-    // MARK: Public
+    // MARK: Request
 
     /// Creates a request with a body.
     ///

--- a/Sources/Exchange/HTTP/HTTPRequest.swift
+++ b/Sources/Exchange/HTTP/HTTPRequest.swift
@@ -44,7 +44,7 @@ import Foundation
 /// > Tip: You can retry the ``HTTPRequest`` if it fails by calling retry methods like ``retry(_:)`` or ``retry(with:)``.
 /// By providing a ``RetryHandler`` or any ``HTTPRequestRetrier``, you can determine if a request should be retried if it fails.
 /// Typical use cases include retrying requests a given number of times in the event of poor network connectivity.
-public class HTTPRequest<Value: Decodable> {
+public struct HTTPRequest<Value: Decodable> {
     
     // MARK: Properties
     
@@ -145,27 +145,27 @@ public class HTTPRequest<Value: Decodable> {
     // MARK: Adapt
     
     /// Applies the provided adaptor to the request.
-    @discardableResult
     public func adapt<A>(with adaptor: A) -> Self where A: HTTPRequestAdaptor {
-        adaptors.append(adaptor)
-        return self
+        var request = self
+        request.adaptors.append(adaptor)
+        return request
     }
     
     // MARK: Retry
     
     /// Applies the provided retrier to the request's retry strategy.
-    @discardableResult
     public func retry<R>(with retrier: R) -> Self where R: HTTPRequestRetrier {
-        retriers.append(retrier)
-        return self
+        var request = self
+        request.retriers.append(retrier)
+        return request
     }
     
     // MARK: Validate
     
     /// Applies the provided validator to the request's response validation.
-    @discardableResult
     public func validate<V>(with validator: V) -> Self where V: HTTPResponseValidator {
-        validators.append(validator)
-        return self
+        var request = self
+        request.validators.append(validator)
+        return request
     }
 }

--- a/Sources/Exchange/HTTP/Plugins/Adaptors/Adaptor.swift
+++ b/Sources/Exchange/HTTP/Plugins/Adaptors/Adaptor.swift
@@ -58,7 +58,6 @@ public struct Adaptor: HTTPRequestAdaptor {
 
 extension HTTPRequest {
     /// Applies an ``Adaptor`` that handles request adaptation using the provided ``AdaptationHandler``.
-    @discardableResult
     public func adapt(_ handler: @escaping AdaptationHandler) -> Self {
         adapt(with: Adaptor(handler))
     }

--- a/Sources/Exchange/HTTP/Plugins/Adaptors/HeadersAdaptor.swift
+++ b/Sources/Exchange/HTTP/Plugins/Adaptors/HeadersAdaptor.swift
@@ -94,7 +94,6 @@ public struct HeadersAdaptor: HTTPRequestAdaptor {
 
 extension HTTPRequest {
     /// Applies a ``HeadersAdaptor`` that appends the provided headers to the request.
-    @discardableResult
     public func adapt(headers: [String: String], strategy: HeadersAdaptor.CollisionStrategy = .useNewerValue) -> Self {
         adapt(with: HeadersAdaptor(headers: headers, strategy:  strategy))
     }

--- a/Sources/Exchange/HTTP/Plugins/Adaptors/ParametersAdaptor.swift
+++ b/Sources/Exchange/HTTP/Plugins/Adaptors/ParametersAdaptor.swift
@@ -60,7 +60,6 @@ public struct ParametersAdaptor: HTTPRequestAdaptor {
 
 extension HTTPRequest {
     /// Applies a ``ParametersAdaptor`` that appends the provided query parameters to the request.
-    @discardableResult
     public func adapt(queryItems: [URLQueryItem]) -> Self {
         adapt(with: ParametersAdaptor(items: queryItems))
     }

--- a/Sources/Exchange/HTTP/Plugins/Adaptors/ZipAdaptor.swift
+++ b/Sources/Exchange/HTTP/Plugins/Adaptors/ZipAdaptor.swift
@@ -66,7 +66,6 @@ public struct ZipAdaptor: HTTPRequestAdaptor {
 
 extension HTTPRequest {
     /// Applies a ``ZipAdaptor`` that bundles up all the provided adaptors.
-    @discardableResult
     public func adapt(zipping adaptors: [any HTTPRequestAdaptor]) -> Self {
         adapt(with: ZipAdaptor(adaptors))
     }

--- a/Sources/Exchange/HTTP/Plugins/Retriers/Retrier.swift
+++ b/Sources/Exchange/HTTP/Plugins/Retriers/Retrier.swift
@@ -68,7 +68,6 @@ public struct Retrier: HTTPRequestRetrier {
 
 extension HTTPRequest {
     /// Applies a ``Retrier`` that handles retry logic using the provided ``RetryHandler``.
-    @discardableResult
     public func retry(_ handler: @escaping RetryHandler) -> Self {
         retry(with: Retrier(handler))
     }

--- a/Sources/Exchange/HTTP/Plugins/Retriers/RetryStrategy.swift
+++ b/Sources/Exchange/HTTP/Plugins/Retriers/RetryStrategy.swift
@@ -388,7 +388,6 @@ open class RetryStrategy: HTTPRequestRetrier {
 
 extension HTTPRequest {
     /// Applies a ``RetryStrategy`` with the provided configuration.
-    @discardableResult
     public func retryStrategy(
         attempts: Int = RetryStrategy.Constants.defaultAttempts,
         methods: Set<HTTPMethod> = RetryStrategy.Constants.defaultMethods,

--- a/Sources/Exchange/HTTP/Plugins/Retriers/ZipRetrier.swift
+++ b/Sources/Exchange/HTTP/Plugins/Retriers/ZipRetrier.swift
@@ -84,7 +84,6 @@ public struct ZipRetrier: HTTPRequestRetrier {
 
 extension HTTPRequest {
     /// Applies a ``ZipRetrier`` that bundles up all the provided retriers.
-    @discardableResult
     public func retry(zipping retriers: [any HTTPRequestRetrier]) -> Self {
         retry(with: ZipRetrier(retriers))
     }

--- a/Sources/Exchange/HTTP/Plugins/Validators/StatusCodeValidator.swift
+++ b/Sources/Exchange/HTTP/Plugins/Validators/StatusCodeValidator.swift
@@ -71,13 +71,11 @@ public struct StatusCodeValidator<S: Sequence>: HTTPResponseValidator where S.It
 
 extension HTTPRequest {
     /// Applies a ``StatusCodeValidator`` that validates the request's response has a status code within the provided sequence.
-    @discardableResult
     public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int {
         validate(with: StatusCodeValidator(statusCode: acceptableStatusCodes))
     }
     
     /// Applies a ``StatusCodeValidator`` that validates the request's response has a status code matching the status code.
-    @discardableResult
     public func validate(statusCode: Int) -> Self {
         validate(with: StatusCodeValidator(statusCode: statusCode))
     }

--- a/Sources/Exchange/HTTP/Plugins/Validators/Validator.swift
+++ b/Sources/Exchange/HTTP/Plugins/Validators/Validator.swift
@@ -55,7 +55,6 @@ public struct Validator: HTTPResponseValidator {
 
 extension HTTPRequest {
     /// Applies a ``Validator`` that validates the request's response using the provided ``ValidationHandler``.
-    @discardableResult
     public func validate(_ handler: @escaping ValidationHandler) -> Self {
         validate(with: Validator(handler))
     }

--- a/Sources/Exchange/HTTP/Plugins/Validators/ZipValidator.swift
+++ b/Sources/Exchange/HTTP/Plugins/Validators/ZipValidator.swift
@@ -68,7 +68,6 @@ public struct ZipValidator: HTTPResponseValidator {
 
 extension HTTPRequest {
     /// Applies a ``ZipValidator`` that bundles up all the provided validators.
-    @discardableResult
     public func validate(zipping validators: [any HTTPResponseValidator]) -> Self {
         validate(with: ZipValidator(validators))
     }

--- a/Tests/ExchangeTests/HTTP/HTTPRequestTests.swift
+++ b/Tests/ExchangeTests/HTTP/HTTPRequestTests.swift
@@ -1252,6 +1252,7 @@ class HTTPRequestTests: XCTestCase {
                 _ = try await client
                     .request(for: .get, to: url, expecting: [String].self)
                     .run()
+                XCTFail("Expected error to be thrown")
             } catch {
                 XCTAssertTrue(error is CancellationError)
                 expectation.fulfill()
@@ -1295,6 +1296,7 @@ class HTTPRequestTests: XCTestCase {
                 _ = try await client
                     .request(for: .get, to: url, expecting: [String].self)
                     .run()
+                XCTFail("Expected error to be thrown")
             } catch {
                 XCTAssertTrue(error is CancellationError)
                 expectation.fulfill()
@@ -1332,6 +1334,7 @@ class HTTPRequestTests: XCTestCase {
                 _ = try await client
                     .request(for: .get, to: url, expecting: [String].self)
                     .run()
+                XCTFail("Expected error to be thrown")
             } catch {
                 XCTAssertTrue(error is CancellationError)
                 expectation.fulfill()

--- a/Tests/ExchangeTests/HTTP/Plugins/Adaptors/AdaptorTests.swift
+++ b/Tests/ExchangeTests/HTTP/Plugins/Adaptors/AdaptorTests.swift
@@ -40,9 +40,9 @@ class AdaptorTests: XCTestCase {
     
     func test_request_adaptorConvenience_isAddedToRequestAdaptors() async throws {
         let client = HTTPClient()
-        let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectation = expectation(description: "Expected adaptor to be called.")
-        request.adapt { request, _ in
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
+            .adapt { request, _ in
             expectation.fulfill()
             return request
         }

--- a/Tests/ExchangeTests/HTTP/Plugins/Adaptors/HeadersAdaptorTests.swift
+++ b/Tests/ExchangeTests/HTTP/Plugins/Adaptors/HeadersAdaptorTests.swift
@@ -116,14 +116,13 @@ class HeadersAdaptorTests: XCTestCase {
     
     func test_request_adaptorConvenience_isAddedToRequestAdaptors() async throws {
         let client = HTTPClient()
-        let request = client.request(for: .get, to: .mock, expecting: String.self)
-        
         let headers: [String: String] = [
             "HEADER-ONE": "VALUE-ONE",
             "HEADER-TWO": "VALUE-TWO",
         ]
         
-        request.adapt(headers: headers)
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
+            .adapt(headers: headers)
         
         guard let adaptor = request.adaptors.first as? HeadersAdaptor else {
             XCTFail("Expected request to container HeadersAdaptor.")

--- a/Tests/ExchangeTests/HTTP/Plugins/Adaptors/ParametersAdaptorTests.swift
+++ b/Tests/ExchangeTests/HTTP/Plugins/Adaptors/ParametersAdaptorTests.swift
@@ -62,13 +62,14 @@ class ParametersAdaptorTests: XCTestCase {
     
     func test_request_adaptorConvenience_isAddedToRequestAdaptors() async throws {
         let client = HTTPClient()
-        let request = client.request(for: .get, to: .mock, expecting: String.self)
         
         let items: [URLQueryItem] = [
             .init(name: "one-name", value: "one-value"),
             .init(name: "two-name", value: "two-value"),
         ]
-        request.adapt(queryItems: items)
+        
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
+            .adapt(queryItems: items)
         
         guard let adaptor = request.adaptors.first as? ParametersAdaptor else {
             XCTFail("Expected request to container PrametersAdaptor.")

--- a/Tests/ExchangeTests/HTTP/Plugins/Adaptors/ZipAdaptorTests.swift
+++ b/Tests/ExchangeTests/HTTP/Plugins/Adaptors/ZipAdaptorTests.swift
@@ -68,6 +68,7 @@ class ZipAdaptorTests: XCTestCase {
         task = Task {
             do {
                 _ = try await zipAdaptor.adapt(.mock, for: .shared)
+                XCTFail("Expected error to be thrown")
             } catch {
                 XCTAssertTrue(error is CancellationError)
             }
@@ -78,19 +79,19 @@ class ZipAdaptorTests: XCTestCase {
     
     func test_zipAdaptor_adaptorConvenience_isAddedToRequestAdaptors() async throws {
         let client = HTTPClient()
-        let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectationOne = expectation(description: "Expected adaptor one to be called.")
         let expectationTwo = expectation(description: "Expected adaptor two to be called.")
-        request.adapt(zipping: [
-            Adaptor { request, _ in
-                expectationOne.fulfill()
-                return request
-            },
-            Adaptor { request, _ in
-                expectationTwo.fulfill()
-                return request
-            },
-        ])
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
+            .adapt(zipping: [
+                Adaptor { request, _ in
+                    expectationOne.fulfill()
+                    return request
+                },
+                Adaptor { request, _ in
+                    expectationTwo.fulfill()
+                    return request
+                },
+            ])
         
         _ = try await request.adaptors.first?.adapt(request.request, for: client.dispatcher.session)
         

--- a/Tests/ExchangeTests/HTTP/Plugins/Retriers/RetrierTests.swift
+++ b/Tests/ExchangeTests/HTTP/Plugins/Retriers/RetrierTests.swift
@@ -49,12 +49,12 @@ class RetrierTests: XCTestCase {
         struct MockError: Error {}
         
         let client = HTTPClient()
-        let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectation = expectation(description: "Expected retrier to be called.")
-        request.retry { _, _, _, _, _ in
-            expectation.fulfill()
-            return .concede
-        }
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
+            .retry { _, _, _, _, _ in
+                expectation.fulfill()
+                return .concede
+            }
         
         _ = try await request.retriers.first?.retry(
             request.request,

--- a/Tests/ExchangeTests/HTTP/Plugins/Retriers/RetryStrategyTests.swift
+++ b/Tests/ExchangeTests/HTTP/Plugins/Retriers/RetryStrategyTests.swift
@@ -281,14 +281,14 @@ class RetryStrategyTests: XCTestCase {
     func test_retryStrategy_retrierConvenience_isAddedToRequestRetriers() async throws {
         let client = HTTPClient(dispatcher: .mock(responses: [.mock: .failure(URLError(.badURL))]))
         let request = client.request(for: .get, to: .mock, expecting: String.self)
-        request.retryStrategy(
-            attempts: 999,
-            methods: [.get],
-            urlErrorCodes: [.badURL],
-            statusCodes: [401],
-            exponentialBackoffBase: 1,
-            jitterStrategy: .full
-        )
+            .retryStrategy(
+                attempts: 999,
+                methods: [.get],
+                urlErrorCodes: [.badURL],
+                statusCodes: [401],
+                exponentialBackoffBase: 1,
+                jitterStrategy: .full
+            )
         
         guard let retrier = request.retriers.first as? RetryStrategy else {
             XCTFail("Expected first retrier to be a RetryStrategy.")

--- a/Tests/ExchangeTests/HTTP/Plugins/Retriers/ZipRetrierTests.swift
+++ b/Tests/ExchangeTests/HTTP/Plugins/Retriers/ZipRetrierTests.swift
@@ -80,6 +80,7 @@ class ZipRetrierTests: XCTestCase {
                     dueTo: URLError(.cannotParseResponse),
                     previousAttempts: 0
                 )
+                XCTFail("Expected error to be thrown")
             } catch {
                 XCTAssertTrue(error is CancellationError)
             }
@@ -90,19 +91,19 @@ class ZipRetrierTests: XCTestCase {
     
     func test_zipRetrier_retrierConvenience_isAddedToRequestRetriers() async throws {
         let client = HTTPClient()
-        let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectationOne = expectation(description: "Expected retrier one to be called.")
         let expectationTwo = expectation(description: "Expected retrier two to be called.")
-        request.retry(zipping: [
-            Retrier { _, _, _, _, _ in
-                expectationOne.fulfill()
-                return .concede
-            },
-            Retrier { _, _, _, _, _ in
-                expectationTwo.fulfill()
-                return .concede
-            },
-        ])
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
+            .retry(zipping: [
+                Retrier { _, _, _, _, _ in
+                    expectationOne.fulfill()
+                    return .concede
+                },
+                Retrier { _, _, _, _, _ in
+                    expectationTwo.fulfill()
+                    return .concede
+                },
+            ])
         
         _ = try await request.retriers.first?.retry(
             request.request,

--- a/Tests/ExchangeTests/HTTP/Plugins/Validators/StatusCodeValidatorTests.swift
+++ b/Tests/ExchangeTests/HTTP/Plugins/Validators/StatusCodeValidatorTests.swift
@@ -83,7 +83,7 @@ class StatusCodeValidatorTests: XCTestCase {
     func test_request_singleStatusCodeValidationConvenience_isAddedToRequestValidators() async {
         let client = HTTPClient()
         let request = client.request(for: .get, to: .mock, expecting: String.self)
-        request.validate(statusCode: 200)
+            .validate(statusCode: 200)
         guard let validator = request.validators.first as? StatusCodeValidator<ClosedRange<Int>> else {
             XCTFail("Expected a ClosedRange<Int> StatusCodeValidator")
             return
@@ -95,7 +95,7 @@ class StatusCodeValidatorTests: XCTestCase {
     func test_request_sequenceStatusCodeValidationConvenience_isAddedToRequestValidators() async {
         let client = HTTPClient()
         let request = client.request(for: .get, to: .mock, expecting: String.self)
-        request.validate(statusCode: 200...299)
+            .validate(statusCode: 200...299)
         guard let validator = request.validators.first as? StatusCodeValidator<ClosedRange<Int>> else {
             XCTFail("Expected a ClosedRange<Int> StatusCodeValidator")
             return

--- a/Tests/ExchangeTests/HTTP/Plugins/Validators/ValidatorTests.swift
+++ b/Tests/ExchangeTests/HTTP/Plugins/Validators/ValidatorTests.swift
@@ -34,20 +34,20 @@ class ValidatorTests: XCTestCase {
             return .success
         }
     
-        _ = try await validator.validate(HTTPURLResponse(), for: request.request, with: Data())
+        _ = await validator.validate(HTTPURLResponse(), for: request.request, with: Data())
         await fulfillment(of: [expectation])
     }
     
     func test_request_validatorConvenience_isAddedToRequestValidators() async throws {
         let client = HTTPClient()
-        let request = client.request(for: .get, to: .mock, expecting: String.self)
         let expectation = expectation(description: "Expected adaptor to be called.")
-        request.validate { _, _, _ in
-            expectation.fulfill()
-            return .success
-        }
+        let request = client.request(for: .get, to: .mock, expecting: String.self)
+            .validate { _, _, _ in
+                expectation.fulfill()
+                return .success
+            }
         
-        _ = try await request.validators.first?.validate(HTTPURLResponse(), for: request.request, with: Data())
+        _ = await request.validators.first?.validate(HTTPURLResponse(), for: request.request, with: Data())
         
         await fulfillment(of: [expectation])
     }


### PR DESCRIPTION
- Also allows the mutation of `HTTPClient` plugins.